### PR TITLE
Rename husky_empty_world.launch to empty_world.launch

### DIFF
--- a/docs/robots/outdoor_robots/husky/tutorials_husky.mdx
+++ b/docs/robots/outdoor_robots/husky/tutorials_husky.mdx
@@ -1183,7 +1183,7 @@ Refer to the [Jetson](/docs/computers/jetson/jetson_hardware) page for details o
 
 In addtion to the default `husky_playpen.launch` file, `husky_gazebo` contains two additional launch files of use:
 
-- `husky_empty_world.launch`, which spawns Husky in a featureless, infinite plane; and
+- `empty_world.launch`, which spawns Husky in a featureless, infinite plane; and
 - `spawn_husky.launch`, which is intended to be included in any custom world to add a Husky simulation to it.
 
 To add a Husky to any of your own worlds, simply include the `spawn_husky.launch` file in your own world's launch:


### PR DESCRIPTION
See: https://github.com/husky/husky/pull/270

To make it easier to support multiple platforms with the OutdoorNav simulations we've updated Husky to use the same launch file name as the other platforms.