### PR TITLE
Add illumination to the camera & vision ip range

### DIFF
--- a/docs/tools/network_ip_addresses.mdx
+++ b/docs/tools/network_ip_addresses.mdx
@@ -13,7 +13,7 @@ This chart is for reference, to help you decide what address to assign sensors o
 | Main Robot Computer                         | 192.168.131.1     | -               |
 | Main Robot Microcontroller                  | 192.168.131.2     | -               |
 | Additional Computers and Control Equipment  | 192.168.131.3     | 192.168.131.9   |
-| Camera or Vision Sensor                     | 192.168.131.10    | 192.168.131.19  |
+| Camera, Vision Sensor, Illumination         | 192.168.131.10    | 192.168.131.19  |
 | LiDAR                                       | 192.168.131.20    | 192.168.131.29  |
 | GPS                                         | 192.168.131.30    | 192.168.131.34  |
 | Sonar                                       | 192.168.131.35    | 192.168.131.39  |


### PR DESCRIPTION
IP-controlled lighting should use the same address range as cameras.