### PR TITLE
Add schedule import/export API

### DIFF
--- a/docs_outdoornav_user_manual/api/api_endpoints/definitions.mdx
+++ b/docs_outdoornav_user_manual/api/api_endpoints/definitions.mdx
@@ -1008,6 +1008,18 @@ bool enable
 bool ok
 ```
 
+#### cpr_mission_scheduler_msgs/srv/ExportData.srv {#scheduler-exportdata}
+
+```
+---
+# A base-64 encoded string representing a compressed version of
+# the database contents.
+# The data itself is a gzipped JSON string representing the database contents
+# This can be written to a file or used with the ImportData.srv
+# to back-up/restore the database contents
+string data
+```
+
 #### cpr_mission_scheduler_msgs/srv/GetAllSchedules.srv {#scheduler-getallschedules}
 
 ```
@@ -1033,6 +1045,20 @@ duration time_to_start
 string uuid
 ---
 cpr_mission_scheduler_msgs/Schedule schedule
+```
+
+#### cpr_mission_scheduler_msgs/srv/ImportData.srv {#scheduler-importdata}
+
+```
+# A base-64 encoded string representing a compressed version of
+# the database contents.
+# The data itself is a gzipped JSON string representing the database contents
+# This is the same as the data output by the ExportData service, and is intended
+# to be used to restore the database to a previous state
+string data
+---
+# The state of the database after importing the data
+cpr_mission_scheduler_msgs/StorageState state
 ```
 
 #### cpr_mission_scheduler_msgs/srv/UpdateSchedule.srv {scheduler-updateschedule}

--- a/docs_outdoornav_user_manual/api/api_endpoints/mission_scheduler_api.mdx
+++ b/docs_outdoornav_user_manual/api/api_endpoints/mission_scheduler_api.mdx
@@ -111,6 +111,19 @@ be run automatically.
 
 :::
 
+### mission_scheduler/export_data
+
+**Service Type:** [cpr_mission_scheduler_msgs/srv/ExportData](definitions#scheduler-exportdata)
+
+**Description:** Export all schedule data to a base64 string to it can be backed-up or copied to another robot.
+
+:::note
+
+This service is intended to be used in combination with the `import_data` service to facilitate backups or
+synchronizing schedules across multiple robots.
+
+:::
+
 ### mission_scheduler/get_all_schedules
 
 **Service Type:** [mission_scheduler/srv/GetAllSchedules](definitions#scheduler-getallschedules)
@@ -137,6 +150,20 @@ their designated start time +/- 10 seconds.
 
 **Description:** Get the schedule with the provided UUID. If an error occurred, or no schedule with the provided UUID
 exists, the returned object will have a blank UUID.
+
+### mission_scheduler/import_data
+
+**Service Type:** [cpr_mission_scheduler_msgs/srv/ImportData](definitions#scheduler-importdata)
+
+**Description:** Import data exported by the `export_data` service.  This will delete all schedules and replace the
+database contents with the imported data.
+
+:::note
+
+This service is intended to be used in combination with the `export_data` service to facilitate backups or
+synchronizing schedules across multiple robots.
+
+:::
 
 ### mission_scheduler/remove_mission
 

--- a/docs_outdoornav_user_manual/api/api_endpoints/mission_scheduler_api.mdx
+++ b/docs_outdoornav_user_manual/api/api_endpoints/mission_scheduler_api.mdx
@@ -111,7 +111,7 @@ be run automatically.
 
 :::
 
-### mission_scheduler/export_data
+### mission_scheduler/export
 
 **Service Type:** [cpr_mission_scheduler_msgs/srv/ExportData](definitions#scheduler-exportdata)
 
@@ -151,7 +151,7 @@ their designated start time +/- 10 seconds.
 **Description:** Get the schedule with the provided UUID. If an error occurred, or no schedule with the provided UUID
 exists, the returned object will have a blank UUID.
 
-### mission_scheduler/import_data
+### mission_scheduler/import
 
 **Service Type:** [cpr_mission_scheduler_msgs/srv/ImportData](definitions#scheduler-importdata)
 


### PR DESCRIPTION
Add the new `mission_scheduler/import_data` and `.../export_data` services to the Mission Scheduler API.