### PR TITLE
Enable 'next' version for ONav

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,6 @@ documentation.
 
 During the development phase, follow steps 1-10 of the workflow above. Note that the updates will not affect
 the default view of the user manual, only the "next" version of the manual
-(eg. http://docs.clearpathrobotics.com/docs_outdoornav_user_manual/next/index). You can enable the visibility of the "next" version by setting
-
-```
-includeCurrentVersion: true,
-```
-
-in `docusaurus.config.js` alongside `id: "outdoornav_user_manual",` section. Ensure to reset this to false before releasing the changes.
 
 ### Release Phase
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -77,7 +77,7 @@ const config = {
         remarkPlugins: [math],
         rehypePlugins: [katex],
         showLastUpdateTime: true,
-        includeCurrentVersion: false,
+        includeCurrentVersion: true,
       },
     ],
   ],


### PR DESCRIPTION
As discussed with Jason, enabling the `next` version for OutdoorNav. This turns on the /next path and adds `next` to the version dropdown.