### PR TITLE
Upgrade to node 18

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [18.13.0]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
         - Extension: _Prettier_
         - Extension: _MDX_
     2.  Terminal configured to work with this GitHub repository
-    3.  Node.js (16.x or newer) is installed
+    3.  Node.js (18.x or newer) is installed
         1.  To install `nodejs` LTS (18.x currently) on Ubuntu run: `curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - && sudo apt-get install -y nodejs`
         2.  For all other platforms use: https://nodejs.org/en/download
 2.  Clone this repository,

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
         - Extension: _Prettier_
         - Extension: _MDX_
     2.  Terminal configured to work with this GitHub repository
-    3.  Node.js (18.x or newer) is installed
+    3.  Node.js (18.13.0 or newer) is installed
         1.  To install `nodejs` LTS (18.x currently) on Ubuntu run: `curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - && sudo apt-get install -y nodejs`
         2.  For all other platforms use: https://nodejs.org/en/download
 2.  Clone this repository,


### PR DESCRIPTION
- Updating from Node 16 to Node 18.13.0
- [Node 16 will stop receiving security patches in September 2023](https://github.com/nodejs/release#release-schedule).
- I chose Node 18.13.0 since it is [supported in AWS Amplify's default docker image](https://github.com/aws-amplify/amplify-hosting/issues/3109).
- I have updated AWS already. This Pull Request should update our README documentation, and the GitHub CI actions.