### PR TITLE
Blackfly Addition

### DIFF
--- a/docs_versioned_docs/version-ros2humble/robots/accessories/sensors/cameras/flir_blackfly_s.mdx
+++ b/docs_versioned_docs/version-ros2humble/robots/accessories/sensors/cameras/flir_blackfly_s.mdx
@@ -38,10 +38,17 @@ import Support from "/components/support.mdx";
 
 ## Software Bringup
 
-This sensor is not currently included in the Clearpath Robotics robot package but may be in the future.
-If you purchased this sensor with your Clearpath robot, we will install the necessary ROS packages and configuration details on the robot's computer.
+This sensor is included in the Clearpath Robotics robot package that is installed on all of our robots.
+This allows you to add or remove the sensor from your robot's software description by modifying the
+[robot configuration yaml](../../../../ros/config/yaml.mdx#cameras).
 
-Refer to this page's Further Reading section for more details.
+This sensor also requires additional changes beyond the robot.yaml file. These changes are included by default in the
+Clearpath ISO, but can also be applied using the following command:
+
+```bash
+ros2 run spinnaker_camera_driver linux_setup_flir
+```
+or by following the [manual setup instructions](https://github.com/ros-drivers/flir_camera_driver/blob/humble-devel/spinnaker_camera_driver/docs/linux_setup_flir.md).
 
 ---
 

--- a/docs_versioned_docs/version-ros2humble/ros/config/yaml.mdx
+++ b/docs_versioned_docs/version-ros2humble/ros/config/yaml.mdx
@@ -806,6 +806,21 @@ camera:
         pointcloud.enable: true
 ```
 
+- **_flir_blackfly:_**
+
+```yaml
+camera:
+  - model: flir_blackfly
+    urdf_enabled: true
+    launch_enabled: true
+    parent: fath_pivot_0_mount
+    xyz: [0.0, 0.0, 0.0]
+    rpy: [0.0, 0.0, 0.0]
+    ros_parameters:
+      flir_blackfly:
+        serial_number: 0
+```
+
 ### GPS
 
 - **_swift_nav:_**

--- a/docs_versioned_docs/version-ros2humble/ros/installation/robot.mdx
+++ b/docs_versioned_docs/version-ros2humble/ros/installation/robot.mdx
@@ -125,6 +125,12 @@ To start the services, call
 sudo systemctl daemon-reload && sudo systemctl start clearpath-robot.service
 ```
 
+#### Additional settings
+
+Certain sensors may require additional setup, please review the [Accessories](../../robots/accessories/accessories.mdx) pages
+for any additional instructions for the sensors that you are using. For example, the Blackfly camera has additional instructions
+listed under [software bringup](../../robots/accessories/sensors/cameras/flir_blackfly_s#software-bringup).
+
 ### Option 2: Manual Source Install
 
 #### ROS 2 Humble
@@ -259,3 +265,9 @@ Add the following line to your `~/.bashrc` file to automatically source the gene
 ```
 source /etc/clearpath/setup.bash
 ```
+
+#### Additional settings
+
+Certain sensors may require additional setup, please review the [Accessories](../../robots/accessories/accessories.mdx) pages
+for any additional instructions for the sensors that you are using. For example, the Blackfly camera has additional instructions
+listed under [software bringup](../../robots/accessories/sensors/cameras/flir_blackfly_s#software-bringup).

--- a/docs_versioned_docs/version-ros2humble/ros/ros.mdx
+++ b/docs_versioned_docs/version-ros2humble/ros/ros.mdx
@@ -47,22 +47,22 @@ sensors that have been validated by Clearpath.
 
 :::
 
-| Sensor                                                                               | Type         | Installation     | Driver                                                                                      |
-| :----------------------------------------------------------------------------------- | :----------- | :--------------- | :------------------------------------------------------------------------------------------ |
-| [SICK LMS-111/LMS-151](../robots/accessories/sensors/lidar_2d/sick_lms111.mdx)       | 2D Lidar     | Source or Debian | [LMS1xx](https://github.com/clearpathrobotics/LMS1xx)                                       |
-| [Hokuyo UST10-LX](../robots/accessories/sensors/lidar_2d/hokuyo_ust10_lx.mdx)        | 2D Lidar     | Source or Debian | [urg_node](https://github.com/ros-drivers/urg_node)                                         |
-| [Hokuyo UST20-LX](../robots/accessories/sensors/lidar_2d/hokuyo_ust20_lx.mdx)        | 2D Lidar     | Source or Debian | [urg_node](https://github.com/ros-drivers/urg_node)                                         |
-| [Hokuyo UST30-LX](../robots/accessories/sensors/lidar_2d/hokuyo_ust30_lx.mdx)        | 2D Lidar     | Source or Debian | [urg_node](https://github.com/ros-drivers/urg_node)                                         |
-| [MicroStrain 3DM-GX5](../robots/accessories/sensors/imu/microstrain_3dm_gx5.mdx)     | IMU          | Source or Debian | [microstrain_intertial](https://github.com/LORD-MicroStrain/microstrain_inertial/tree/ros2) |
-| [Redshift Labs UM7](../robots/accessories/sensors/imu/redshift_labs_um7.mdx)         | IMU          | Source           | [um7](https://github.com/ros-drivers/um7/tree/ros2)                                         |
-| CH Robotics UM6                                                                      | IMU          | Source           | [um7](https://github.com/ros-drivers/um7/tree/ros2)                                         |
-| [Velodyne Puck](../robots/accessories/sensors/lidar_3d/velodyne_puck.mdx)            | 3D Lidar     | Source or Debian | [velodyne](https://github.com/ros-drivers/velodyne/tree/ros2)                               |
-| [Garmin GPS 18x](../robots/accessories/sensors/gps/garmin_gps_18x.mdx)               | GPS          | Source           | [nmea_navsat_driver](https://github.com/ros-drivers/nmea_navsat_driver/tree/ros2)           |
-| NovAtel SMART6 and SMART7                                                            | GPS          | Source or Debian | [nmea_navsat_driver](https://github.com/ros-drivers/nmea_navsat_driver/tree/ros2)           |
-| [Swift Navigation Duro](../robots/accessories/sensors/gps/swift_navigation_duro.mdx) | GPS          | Source           | [duro_gps_driver](https://github.com/szenergy/duro_gps_driver/tree/ros2-humble)             |
-| [Flir Blackfly S](../robots/accessories/sensors/cameras/flir_blackfly_s.mdx)         | Camera       | Source           | [flir_camera_driver](https://github.com/ros-drivers/flir_camera_driver/tree/humble-devel)   |
-| [Intel Realsense D435](../robots/accessories/sensors/cameras/realsense_d435.mdx)     | Depth Camera | Source or Debian | [realsense-ros](https://github.com/IntelRealSense/realsense-ros/tree/ros2-development)      |
-| [Stereolabs Zed 2](../robots/accessories/sensors/cameras/stereolabs_zed_2.mdx)       | Depth Camera | Source           | [zed-ros2-wrapper](https://github.com/stereolabs/zed-ros2-wrapper.git)                      |
+| Sensor                                                                               | Type         | Installation | Driver                                                                                      |
+| :----------------------------------------------------------------------------------- | :----------- | :----------- | :------------------------------------------------------------------------------------------ |
+| [SICK LMS-111/LMS-151](../robots/accessories/sensors/lidar_2d/sick_lms111.mdx)       | 2D Lidar     | Debian       | [LMS1xx](https://github.com/clearpathrobotics/LMS1xx)                                       |
+| [Hokuyo UST10-LX](../robots/accessories/sensors/lidar_2d/hokuyo_ust10_lx.mdx)        | 2D Lidar     | Debian       | [urg_node](https://github.com/ros-drivers/urg_node)                                         |
+| [Hokuyo UST20-LX](../robots/accessories/sensors/lidar_2d/hokuyo_ust20_lx.mdx)        | 2D Lidar     | Debian       | [urg_node](https://github.com/ros-drivers/urg_node)                                         |
+| [Hokuyo UST30-LX](../robots/accessories/sensors/lidar_2d/hokuyo_ust30_lx.mdx)        | 2D Lidar     | Debian       | [urg_node](https://github.com/ros-drivers/urg_node)                                         |
+| [MicroStrain 3DM-GX5](../robots/accessories/sensors/imu/microstrain_3dm_gx5.mdx)     | IMU          | Debian       | [microstrain_intertial](https://github.com/LORD-MicroStrain/microstrain_inertial/tree/ros2) |
+| [Redshift Labs UM7](../robots/accessories/sensors/imu/redshift_labs_um7.mdx)         | IMU          | Source       | [um7](https://github.com/ros-drivers/um7/tree/ros2)                                         |
+| CH Robotics UM6                                                                      | IMU          | Source       | [um7](https://github.com/ros-drivers/um7/tree/ros2)                                         |
+| [Velodyne Puck](../robots/accessories/sensors/lidar_3d/velodyne_puck.mdx)            | 3D Lidar     | Debian       | [velodyne](https://github.com/ros-drivers/velodyne/tree/ros2)                               |
+| [Garmin GPS 18x](../robots/accessories/sensors/gps/garmin_gps_18x.mdx)               | GPS          | Source       | [nmea_navsat_driver](https://github.com/ros-drivers/nmea_navsat_driver/tree/ros2)           |
+| NovAtel SMART6 and SMART7                                                            | GPS          | Debian       | [nmea_navsat_driver](https://github.com/ros-drivers/nmea_navsat_driver/tree/ros2)           |
+| [Swift Navigation Duro](../robots/accessories/sensors/gps/swift_navigation_duro.mdx) | GPS          | Source       | [duro_gps_driver](https://github.com/szenergy/duro_gps_driver/tree/ros2-humble)             |
+| [Flir Blackfly S](../robots/accessories/sensors/cameras/flir_blackfly_s.mdx)         | Camera       | Source       | [flir_camera_driver](https://github.com/ros-drivers/flir_camera_driver/tree/humble-devel)   |
+| [Intel Realsense D435](../robots/accessories/sensors/cameras/realsense_d435.mdx)     | Depth Camera | Debian       | [realsense-ros](https://github.com/IntelRealSense/realsense-ros/tree/ros2-development)      |
+| [Stereolabs Zed 2](../robots/accessories/sensors/cameras/stereolabs_zed_2.mdx)       | Depth Camera | Source       | [zed-ros2-wrapper](https://github.com/stereolabs/zed-ros2-wrapper.git)                      |
 
 :::note
 

--- a/docs_versioned_docs/version-ros2humble/ros/ros.mdx
+++ b/docs_versioned_docs/version-ros2humble/ros/ros.mdx
@@ -60,7 +60,7 @@ sensors that have been validated by Clearpath.
 | [Garmin GPS 18x](../robots/accessories/sensors/gps/garmin_gps_18x.mdx)               | GPS          | Source       | [nmea_navsat_driver](https://github.com/ros-drivers/nmea_navsat_driver/tree/ros2)           |
 | NovAtel SMART6 and SMART7                                                            | GPS          | Debian       | [nmea_navsat_driver](https://github.com/ros-drivers/nmea_navsat_driver/tree/ros2)           |
 | [Swift Navigation Duro](../robots/accessories/sensors/gps/swift_navigation_duro.mdx) | GPS          | Source       | [duro_gps_driver](https://github.com/szenergy/duro_gps_driver/tree/ros2-humble)             |
-| [Flir Blackfly S](../robots/accessories/sensors/cameras/flir_blackfly_s.mdx)         | Camera       | Source       | [flir_camera_driver](https://github.com/ros-drivers/flir_camera_driver/tree/humble-devel)   |
+| [Flir Blackfly S](../robots/accessories/sensors/cameras/flir_blackfly_s.mdx)         | Camera       | Debian       | [flir_camera_driver](https://github.com/ros-drivers/flir_camera_driver/tree/humble-devel)   |
 | [Intel Realsense D435](../robots/accessories/sensors/cameras/realsense_d435.mdx)     | Depth Camera | Debian       | [realsense-ros](https://github.com/IntelRealSense/realsense-ros/tree/ros2-development)      |
 | [Stereolabs Zed 2](../robots/accessories/sensors/cameras/stereolabs_zed_2.mdx)       | Depth Camera | Source       | [zed-ros2-wrapper](https://github.com/stereolabs/zed-ros2-wrapper.git)                      |
 


### PR DESCRIPTION
Blackfly now available as Debian, depends on https://github.com/ros-drivers/flir_camera_driver/pull/134