### PR TITLE
Humble install fix

### DIFF
--- a/docs_versioned_docs/version-ros2humble/ros/installation/robot.mdx
+++ b/docs_versioned_docs/version-ros2humble/ros/installation/robot.mdx
@@ -127,6 +127,10 @@ sudo systemctl daemon-reload && sudo systemctl start clearpath-robot.service
 
 ### Option 2: Manual Source Install
 
+<details><summary>Click to expand the manual source install instructions. Only use this option if you
+know what you are doing.</summary>
+<p>
+
 #### ROS 2 Humble
 
 Follow the [official instructions](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html)
@@ -266,3 +270,6 @@ source /etc/clearpath/setup.bash
 Certain sensors may require additional setup, please review the [Accessories](../../robots/accessories/accessories.mdx) pages
 for any additional instructions for the sensors that you are using. For example, the Blackfly camera has additional instructions
 listed under [software bringup](../../robots/accessories/sensors/cameras/flir_blackfly_s#software-bringup).
+
+</p>
+</details>

--- a/docs_versioned_docs/version-ros2humble/ros/installation/robot.mdx
+++ b/docs_versioned_docs/version-ros2humble/ros/installation/robot.mdx
@@ -249,6 +249,7 @@ Clearpath robot services can now be installed with the following command:
 ```
 source /opt/ros/humble/setup.bash
 ros2 run clearpath_robot install
+sudo systemctl enable clearpath-robot
 ```
 
 This script uses [robot_upstart](https://github.com/clearpathrobotics/robot_upstart/tree/foxy-devel) to install the `systemd` services

--- a/docs_versioned_docs/version-ros2humble/ros/installation/robot.mdx
+++ b/docs_versioned_docs/version-ros2humble/ros/installation/robot.mdx
@@ -125,12 +125,6 @@ To start the services, call
 sudo systemctl daemon-reload && sudo systemctl start clearpath-robot.service
 ```
 
-#### Additional settings
-
-Certain sensors may require additional setup, please review the [Accessories](../../robots/accessories/accessories.mdx) pages
-for any additional instructions for the sensors that you are using. For example, the Blackfly camera has additional instructions
-listed under [software bringup](../../robots/accessories/sensors/cameras/flir_blackfly_s#software-bringup).
-
 ### Option 2: Manual Source Install
 
 #### ROS 2 Humble

--- a/docs_versioned_docs/version-ros2humble/ros/installation/robot.mdx
+++ b/docs_versioned_docs/version-ros2humble/ros/installation/robot.mdx
@@ -231,7 +231,7 @@ in the [ROS2 Environment](../config/yaml.mdx#ros-2-environment) section.
 Create the setup folder where the [robot.yaml](../config/yaml.mdx) file will be stored, and where files will be generated:
 
 ```
-sudo mkdir /etc/clearpath/ -p && sudo chmod 666 /etc/clearpath/
+sudo mkdir /etc/clearpath/ -p && sudo chmod 777 /etc/clearpath/
 ```
 #### Robot YAML
 


### PR DESCRIPTION
- Updated folder rights command to match install script
- Enable the clearpath-robot service manually since it is not being done automatically
- Removing some instructions regarding additional sensors from option 1, since it is currently all being handled by the install script and was causing confusion.
- Collapsed manual install instructions because it was causing confusion (people doing some of those steps after completing Option 1).