### PR TITLE
Minor cleanup for 'Getting New Packages'

### DIFF
--- a/components/maintenance/getting_new_packages.mdx
+++ b/components/maintenance/getting_new_packages.mdx
@@ -4,8 +4,6 @@ If you are upgrading your robot from an older version of ROS, please refer to ou
 
 :::
 
-### Getting New Packages
-
 Clearpath Robotics robots are always being improved, both its own software and the many community ROS packages upon which it depends!
 You can use the `apt` package management system to receive new versions all software running on the platform.
 

--- a/docs_versioned_docs/version-ros1noetic/robots/indoor_robots/boxer/maintenance_boxer.mdx
+++ b/docs_versioned_docs/version-ros1noetic/robots/indoor_robots/boxer/maintenance_boxer.mdx
@@ -5,7 +5,6 @@ sidebar_position: 4
 ---
 
 import ComponentIntroductionBoxer from "/components/introduction_boxer.mdx";
-import GettingNewPackages from "/components/maintenance/getting_new_packages.mdx";
 import Support from "/components/support.mdx";
 
 <ComponentIntroductionBoxer />

--- a/docs_versioned_docs/version-ros1noetic/robots/indoor_robots/ridgeback/maintenance_ridgeback.mdx
+++ b/docs_versioned_docs/version-ros1noetic/robots/indoor_robots/ridgeback/maintenance_ridgeback.mdx
@@ -37,6 +37,8 @@ Please contact Clearpath Robotics for additional information about Ridgeback's b
 
 ## Software Maintenance {#software_maintenance}
 
+### Getting New Packages
+
 <GettingNewPackages />
 
 ### MCU Firmware Update

--- a/docs_versioned_docs/version-ros1noetic/robots/outdoor_robots/husky/maintenance_husky.mdx
+++ b/docs_versioned_docs/version-ros1noetic/robots/outdoor_robots/husky/maintenance_husky.mdx
@@ -242,6 +242,8 @@ The [Common Replacement Items](#husky_maintenance_common_replacement_items) sect
 
 ## Software Maintenance {#software_maintenance}
 
+### Getting New Packages
+
 <GettingNewPackages />
 
 ### MCU Firmware Update

--- a/docs_versioned_docs/version-ros1noetic/robots/outdoor_robots/jackal/maintenance_jackal.mdx
+++ b/docs_versioned_docs/version-ros1noetic/robots/outdoor_robots/jackal/maintenance_jackal.mdx
@@ -12,6 +12,8 @@ import Support from "/components/support.mdx";
 
 ## Software Maintenance {#software_maintenance}
 
+### Getting New Packages
+
 <GettingNewPackages />
 
 ### MCU Firmware Update

--- a/docs_versioned_docs/version-ros1noetic/robots/outdoor_robots/warthog/maintenance_warthog.mdx
+++ b/docs_versioned_docs/version-ros1noetic/robots/outdoor_robots/warthog/maintenance_warthog.mdx
@@ -158,6 +158,8 @@ If your unit came equipped with the tread upgrade, please keep the following con
 
 ## Software Maintenance {#software_maintenance}
 
+### Getting New Packages
+
 <GettingNewPackages />
 
 ### MCU Firmware Update

--- a/docs_versioned_docs/version-ros1noetic/robots/solutions/husky_observer/maintenance_husky_observer.mdx
+++ b/docs_versioned_docs/version-ros1noetic/robots/solutions/husky_observer/maintenance_husky_observer.mdx
@@ -232,7 +232,18 @@ the filters on those fans do not require regular maintenance.
 
 ## Software Maintenance {#software_maintenance}
 
+### Getting New Packages
+
 <GettingNewPackages />
+
+:::note
+
+In addition to the core software packages, which can be upgraded through the commands
+noted above, Husky Observer also includes OutdoorNav software, which can be
+upgraded through the commands outlined [here](/docs_outdoornav_user_manual/integration_requirements/software_integration_instructions).
+Contact [Support](#support) if you need more details on updating Husky Observer software.
+
+:::
 
 ### MCU Firmware Update
 

--- a/docs_versioned_docs/version-ros2humble/robots/indoor_robots/dingo/maintenance_dingo.mdx
+++ b/docs_versioned_docs/version-ros2humble/robots/indoor_robots/dingo/maintenance_dingo.mdx
@@ -75,6 +75,8 @@ The initial stage will take 2 - 4 hours, and a complete charge may take up to 8 
 
 ## Software Maintenance {#software_maintenance}
 
+### Getting New Packages
+
 <GettingNewPackages />
 
 ### MCU Firmware Update

--- a/docs_versioned_docs/version-ros2humble/robots/indoor_robots/ridgeback/maintenance_ridgeback.mdx
+++ b/docs_versioned_docs/version-ros2humble/robots/indoor_robots/ridgeback/maintenance_ridgeback.mdx
@@ -37,6 +37,8 @@ Please contact Clearpath Robotics for additional information about Ridgeback's b
 
 ## Software Maintenance {#software_maintenance}
 
+### Getting New Packages
+
 <GettingNewPackages />
 
 ### MCU Firmware Update

--- a/docs_versioned_docs/version-ros2humble/robots/outdoor_robots/husky/maintenance_husky.mdx
+++ b/docs_versioned_docs/version-ros2humble/robots/outdoor_robots/husky/maintenance_husky.mdx
@@ -242,6 +242,8 @@ The [Common Replacement Items](#husky_maintenance_common_replacement_items) sect
 
 ## Software Maintenance {#software_maintenance}
 
+### Getting New Packages
+
 <GettingNewPackages />
 
 ### MCU Firmware Update

--- a/docs_versioned_docs/version-ros2humble/robots/outdoor_robots/jackal/maintenance_jackal.mdx
+++ b/docs_versioned_docs/version-ros2humble/robots/outdoor_robots/jackal/maintenance_jackal.mdx
@@ -13,6 +13,8 @@ import Support from "/components/support.mdx";
 
 ## Software Maintenance {#software_maintenance}
 
+### Getting New Packages
+
 <GettingNewPackages />
 
 ### MCU Firmware Update

--- a/docs_versioned_docs/version-ros2humble/robots/outdoor_robots/warthog/maintenance_warthog.mdx
+++ b/docs_versioned_docs/version-ros2humble/robots/outdoor_robots/warthog/maintenance_warthog.mdx
@@ -158,6 +158,8 @@ If your unit came equipped with the tread upgrade, please keep the following con
 
 ## Software Maintenance {#software_maintenance}
 
+### Getting New Packages
+
 <GettingNewPackages />
 
 ### MCU Firmware Update


### PR DESCRIPTION
* Moved the 'Getting New Packages' header into the individuals files so that it shows up in the table of contents
* Added more details for Husky Observer software updates