### PR TITLE
Corrected Warthog tutorial page 

### DIFF
--- a/docs_versioned_docs/version-ros2humble/robots/outdoor_robots/warthog/tutorials_warthog.mdx
+++ b/docs_versioned_docs/version-ros2humble/robots/outdoor_robots/warthog/tutorials_warthog.mdx
@@ -16,11 +16,9 @@ import Support from "/components/support.mdx";
 
 Clearpath Robotics Warthog is a rugged, all-terrain unmanned ground vehicle.
 
-The Warthog is currently only supported in [ROS 1](/docs_versioned_docs/version-ros1noetic/robots/outdoor_robots/warthog/tutorials_warthog.mdx).
-
 For more information or to receive a quote, please [visit us online](http://clearpathrobotics.com/warthog).
 
-<!-- <ComponentTutorialLinks /> -->
+<ComponentTutorialLinks />
 
 ---
 


### PR DESCRIPTION
The Warthog tutorial page no longer states that it is only compatible with ROS1. I also re-enabled the link to the ROS2 tutorials, so that is now available on the Warthog tutorials page. 