### PR TITLE
Remove the '**/components/** files from sitemap.xml. 

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -30,6 +30,9 @@ const config = {
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
         },
+        sitemap: {
+          ignorePatterns: ['**/components/**'],
+        },
       },
     ],
   ],


### PR DESCRIPTION
This prevents them from getting included in the search as they are only used as embedded in other pages. (#313)