### PR TITLE
Rename IMU data topics for Camera, 3D Lidar sensors

### DIFF
--- a/docs_versioned_docs/version-ros2jazzy/ros/api/sensors_api.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/api/sensors_api.mdx
@@ -21,10 +21,11 @@ each new sensor of that type that is added. Internal sensors such as IMU's will 
 
 ## 3D Lidar topics
 
-| Topic                     | Message type                                                                                                     | Description           | QoS                                           |
-| :------------------------ | :--------------------------------------------------------------------------------------------------------------- | :-------------------- | :-------------------------------------------- |
-| sensors/lidar3d\_#/points | [sensor_msgs/PointCloud2](https://github.com/ros2/common_interfaces/blob/jazzy/sensor_msgs/msg/PointCloud2.msg) | Lidar pointcloud data | [System Default](overview.mdx#system-default) |
-| sensors/lidar3d\_#/scan   | [sensor_msgs/LaserScan](https://github.com/ros2/common_interfaces/blob/jazzy/sensor_msgs/msg/LaserScan.msg)     | Lidar scan data       | [System Default](overview.mdx#system-default) |
+| Topic                           | Message type                                                                                                    | Description           | QoS                                           |
+| :------------------------------ | :-------------------------------------------------------------------------------------------------------------- | :-------------------- | :-------------------------------------------- |
+| sensors/lidar3d\_#/points       | [sensor_msgs/PointCloud2](https://github.com/ros2/common_interfaces/blob/jazzy/sensor_msgs/msg/PointCloud2.msg) | Lidar pointcloud data | [System Default](overview.mdx#system-default) |
+| sensors/lidar3d\_#/scan         | [sensor_msgs/LaserScan](https://github.com/ros2/common_interfaces/blob/jazzy/sensor_msgs/msg/LaserScan.msg)     | Lidar scan data       | [System Default](overview.mdx#system-default) |
+| sensors/lidar3d\_#/imu/data_raw | [sensor_msgs/Imu](https://github.com/ros2/common_interfaces/blob/jazzy/sensor_msgs/msg/Imu.msg)                 | IMU data              | [System Default](overview.mdx#system-default) |
 
 ## Camera topics
 
@@ -35,7 +36,7 @@ each new sensor of that type that is added. Internal sensors such as IMU's will 
 | sensors/camera\_#/depth/image       | [sensor_msgs/Image](https://github.com/ros2/common_interfaces/blob/jazzy/sensor_msgs/msg/Image.msg)             | Raw depth image | [System Default](overview.mdx#system-default) |
 | sensors/camera\_#/depth/camera_info | [sensor_msgs/CameraInfo](https://github.com/ros2/common_interfaces/blob/jazzy/sensor_msgs/msg/CameraInfo.msg)   | Camera Info     | [System Default](overview.mdx#system-default) |
 | sensors/camera\_#/points            | [sensor_msgs/PointCloud2](https://github.com/ros2/common_interfaces/blob/jazzy/sensor_msgs/msg/PointCloud2.msg) | Pointcloud data | [System Default](overview.mdx#system-default) |
-| sensors/camera\_#/imu               | [sensor_msgs/Imu](https://github.com/ros2/common_interfaces/blob/jazzy/sensor_msgs/msg/Imu.msg)                 | IMU data        | [System Default](overview.mdx#system-default) |
+| sensors/camera\_#/imu/data_raw      | [sensor_msgs/Imu](https://github.com/ros2/common_interfaces/blob/jazzy/sensor_msgs/msg/Imu.msg)                 | IMU data        | [System Default](overview.mdx#system-default) |
 
 ## IMU topics
 


### PR DESCRIPTION
Update lidar & camera IMU topics to match RPSW-2503, -2504, and -2505.