### PR TITLE
Add A300 battery options

### DIFF
--- a/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/platform/battery.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/platform/battery.mdx
@@ -33,15 +33,6 @@ For systems without a BMS, the state of charge should be treated as a rough esti
 | `S_24V20_U1` | Lithium Ion | 25.6V | 20.0 | S1P2<br/>S1P4<br/>S1P6 |
 
   </TabItem>
-  <TabItem value="J100" label="J100">
-
-| Battery | Chemistry | Nominal Voltage (V) | Capacity (Ah) | Configurations |
-|:-:|:-:|:-:|:-:|:-:|
-| `HE2613` | Lithium Ion | 25.9 | 12.8 | S1P1 |
-| `HE2411` | Lithium Ion | 25.3 | 11.6 | S1P1 |
-| `HE2410` | Lithium Ion | 25.3 |  9.8 | S1P1 |
-
-  </TabItem>
   <TabItem value="A200" label="A200">
 
 | Battery | Chemistry | Nominal Voltage (V) | Capacity (Ah) | Configurations |

--- a/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/platform/battery.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/platform/battery.mdx
@@ -26,7 +26,23 @@ For systems without a BMS, the state of charge should be treated as a rough esti
 
 
 <Tabs groupId="platform">
-  <TabItem value="A200" label="A200" default>
+  <TabItem value="A300" label="A300" default>
+
+| Battery | Chemistry | Nominal Voltage (V) | Capacity (Ah) | Configurations |
+|:-:|:-:|:-:|:-:|:-:|
+| `S_24V20_U1` | Lithium Ion | 25.6V | 20.0 | S1P2<br/>S1P4<br/>S1P6 |
+
+  </TabItem>
+  <TabItem value="J100" label="J100">
+
+| Battery | Chemistry | Nominal Voltage (V) | Capacity (Ah) | Configurations |
+|:-:|:-:|:-:|:-:|:-:|
+| `HE2613` | Lithium Ion | 25.9 | 12.8 | S1P1 |
+| `HE2411` | Lithium Ion | 25.3 | 11.6 | S1P1 |
+| `HE2410` | Lithium Ion | 25.3 |  9.8 | S1P1 |
+
+  </TabItem>
+  <TabItem value="A200" label="A200">
 
 | Battery | Chemistry | Nominal Voltage (V) | Capacity (Ah) | Configurations |
 |:-:|:-:|:-:|:-:|:-:|


### PR DESCRIPTION
Add A300 tab page (set as default, replacing A200), add `S_24V20_U1` battery with `S1P2`/`S1P4`/`S1P6` configurations.