### PR TITLE
CSS for autonumbering headings

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -76,3 +76,36 @@ safety-icon {
   font-weight: bold;
   color: var(--toc-active-link-color);
 }
+
+body {
+  counter-reset: h2_section h3_section h4_section h5_section h6_section;
+}
+
+h2::before {
+  content: counter(h2_section) ". ";
+  counter-increment: h2_section;
+  counter-set: h3_section 0;
+}
+
+h3::before {
+  content: counter(h2_section) "." counter(h3_section) " ";
+  counter-increment: h3_section;
+  counter-set: h4_section 0;
+}
+
+h4::before {
+  content: counter(h2_section) "." counter(h3_section) "." counter(h4_section) " ";
+  counter-increment: h4_section;
+  counter-set: h5_section 0;
+}
+
+h5::before {
+  content: counter(h2_section) "." counter(h3_section) "." counter(h4_section) "." counter(h5_section) " ";
+  counter-increment: h5_section;
+  counter-set: h6_section 0;
+}
+
+h6::before {
+  content: counter(h2_section) "." counter(h3_section) "." counter(h4_section) "." counter(h5_section) "." counter(h6_section) " ";
+  counter-increment: h6_section;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -77,6 +77,11 @@ safety-icon {
   color: var(--toc-active-link-color);
 }
 
+.homepage-robot-header {
+  font-size: 1.2em;
+  font-weight: bold;
+}
+
 body {
   counter-reset: h2_section h3_section h4_section h5_section h6_section;
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -64,8 +64,8 @@ function Feature({ feature, className }: { feature: FeatureItem; className?: str
           loading="lazy"
         />
       </a>
-      <h3 className={clsx(styles.featureHeading)}>{feature.title}</h3>
-      <p className="padding-horiz--md">{feature.text}</p>
+      <p className="homepage-robot-header">{feature.title}</p>
+      <p>{feature.text}</p>
     </div>
   );
 }

--- a/src/theme/Admonition/Types.js
+++ b/src/theme/Admonition/Types.js
@@ -14,7 +14,7 @@ function SafetyDangerAdmonition(props) {
         />
       </div>
       <div>
-        <h5 style={{ fontSize: 24, color: 'black' }}>{titleLabel}</h5>
+        <p style={{ fontSize: 24, color: 'black' }}><b>{titleLabel}</b></p>
         <p style={{ color: 'black' }}>{props.children}</p>
       </div>
     </div>
@@ -33,7 +33,7 @@ function SafetyWarningAdmonition(props) {
         />
       </div>
       <div>
-        <h5 style={{ fontSize: 24, color: 'black' }}>{titleLabel}</h5>
+        <p style={{ fontSize: 24, color: 'black' }}><b>{titleLabel}</b></p>
         <p style={{ color: 'black' }}>{props.children}</p>
       </div>
     </div>
@@ -52,7 +52,7 @@ function SafetyCautionAdmonition(props) {
         />
       </div>
       <div>
-        <h5 style={{ fontSize: 24, color: 'black' }}>{titleLabel}</h5>
+        <p style={{ fontSize: 24, color: 'black' }}><b>{titleLabel}</b></p>
         <p style={{ color: 'black' }}>{props.children}</p>
       </div>
     </div>


### PR DESCRIPTION
-  Added CSS to have h2 - h6 headings render with an autonumbered prefix
- Removed heading elements from safety admonitions
- Removed heading elements from homepage features