### PR TITLE
Add a new update section to cover how to install updates

### DIFF
--- a/docs_versioned_docs/version-ros2jazzy/ros/installation/controller.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/installation/controller.mdx
@@ -1,7 +1,7 @@
 ---
 title: Joystick Controller Pairing
 sidebar_label: Joystick Controller
-sidebar_position: 4
+sidebar_position: 5
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 ---

--- a/docs_versioned_docs/version-ros2jazzy/ros/installation/offboard_pc.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/installation/offboard_pc.mdx
@@ -1,7 +1,7 @@
 ---
 title: Offboard Computer Setup
 sidebar_label: Offboard Computer
-sidebar_position: 3
+sidebar_position: 4
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 ---

--- a/docs_versioned_docs/version-ros2jazzy/ros/installation/robot.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/installation/robot.mdx
@@ -1,7 +1,7 @@
 ---
 title: Robot Installation
 sidebar_label: Robot
-sidebar_position: 2
+sidebar_position: 3
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 ---

--- a/docs_versioned_docs/version-ros2jazzy/ros/installation/updates.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/installation/updates.mdx
@@ -1,0 +1,124 @@
+---
+title: Installing Updates
+sidebar_label: Installing Updates
+sidebar_position: 1
+toc_min_heading_level: 2
+toc_max_heading_level: 4
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+## Updating Debian Packages
+
+Most software on your robot is installed as **debian packages** managed by Ubuntu. To update
+these packages, connect your robot to the internet (either with a
+[wired](../networking/computer_setup#standard-clearpath-bridge) or
+[wireless](../networking/computer_setup#connecting-to-an-existing-wi-fi-network)
+connection) and run the following commands:
+
+:::note
+
+The `apt` command is recommended by Ubuntu, though the older `apt-get` command is still supported.
+Both will have the same result of updating packages on the system, so pick whichever command you
+prefer.
+
+:::
+
+<Tabs>
+    <TabItem default value="apt">
+        ```bash
+        sudo apt update
+        sudo apt full-upgrade
+        ```
+    </TabItem>
+    <TabItem default value="apt-get">
+        ```bash
+        sudo apt-get update
+        sudo apt-get dist-upgrade
+        ```
+    </TabItem>
+</Tabs>
+
+## Updating Source Packages
+
+If you have ROS packages installed [from source](../tutorials/cheat_sheet#workspaces) you must
+update them manually. Most source packages will be downloaded using `git`, though some software
+may use different version control software including `svn` or `cvs`.
+
+To update your source packages, run the following commands:
+
+<Tabs>
+    <TabItem default value="git">
+        ```bash
+        cd /path/to/colcon_ws/src/my_package
+        git pull
+        ```
+    </TabItem>
+    <TabItem default value="svn">
+        ```bash
+        cd /path/to/colcon_ws/src/my_package
+        svn update
+        ```
+    </TabItem>
+    <TabItem default value="cvs">
+        ```bash
+        cd /path/to/colcon_ws/src/my_package
+        cvs update
+        ```
+    </TabItem>
+</Tabs>
+
+You must update each source package indivudually. If your workspace uses `vcstool` you can
+update all of the packages at once by running
+
+```bash
+cd /path/to/colcon_ws/src
+vcs pull
+```
+
+Once you have updated the source packages in your workspace, rebuild it:
+```bash
+cd /path/to/colcon_ws
+colcon build
+```
+
+
+## Updating Firmware
+
+After updating packages, your robot may need to have MCU and motor controller firmware updated.
+Check your robot's diagnostics to see if a firmware update is available. If so, follow the
+firmware update process for your Clearpath platform:
+
+<Tabs>
+    <TabItem value="Husky A300" default>
+        Husky A300 updates:
+        1. [MCU firmware update](/docs_robots/outdoor_robots/husky/a300/maintenance_husky#mcu_firmware_update)
+        2. [Motor controller firmware update](/docs_robots/outdoor_robots/husky/a300/maintenance_husky#maintenance_husky_motor_controller_firmware)
+    </TabItem>
+    <TabItem value="Husky A200">
+        :::note
+        The Husky A200 does not require firmware updates
+        :::
+    </TabItem>
+    <TabItem value="Jackal">
+        Jackal J100 updates:
+        1. [MCU firmware update](/docs_robots/outdoor_robots/jackal/maintenance_jackal#mcu-firmware-update)
+    </TabItem>
+    <TabItem value="Dingo D150">
+        Dingo DO150 and DD150 updates:
+        1. [MCU firmware update](/docs_robots/indoor_robots/dingo/maintenance_dingo#mcu-firmware-update)
+    </TabItem>
+    <TabItem value="Dingo D100">
+        Dingo DO100 and DD100 updates:
+        1. [MCU firmware update](/docs_robots/indoor_robots/dingo/maintenance_dingo#mcu-firmware-update)
+    </TabItem>
+    <TabItem value="Ridgeback">
+        Ridgeback R100 updates:
+        1. [MCU firmware update](/docs_robots/indoor_robots/ridgeback/maintenance_ridgeback#mcu-firmware-update)
+    </TabItem>
+    <TabItem value="Warthog">
+        Warthog W200 updates:
+        1. [MCU firmware update](/docs_robots/outdoor_robots/warthog/maintenance_warthog#mcu-firmware-update)
+    </TabItem>
+</Tabs>

--- a/docs_versioned_docs/version-ros2jazzy/ros/installation/updates.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/installation/updates.mdx
@@ -103,7 +103,7 @@ firmware update process for your Clearpath platform:
 <Tabs>
     <TabItem value="Husky A300" default>
         Husky A300 updates:
-        1. [MCU firmware update](/docs/ros/installation/robot#firmware-update)
+        1. [MCU firmware update](robot#firmware-update)
         2. [Motor controller firmware update](/docs_robots/outdoor_robots/husky/a300/maintenance_husky#maintenance_husky_motor_controller_firmware)
     </TabItem>
     <TabItem value="Husky A200">
@@ -113,22 +113,22 @@ firmware update process for your Clearpath platform:
     </TabItem>
     <TabItem value="Jackal">
         Jackal J100 updates:
-        1. [MCU firmware update](/docs/ros/installation/robot#firmware-update)
+        1. [MCU firmware update](robot#firmware-update)
     </TabItem>
     <TabItem value="Dingo DX150">
         Dingo DO150 and DD150 updates:
-        1. [MCU firmware update](/docs/ros/installation/robot#firmware-update)
+        1. [MCU firmware update](robot#firmware-update)
     </TabItem>
     <TabItem value="Dingo DX100">
         Dingo DO100 and DD100 updates:
-        1. [MCU firmware update](/docs/ros/installation/robot#firmware-update)
+        1. [MCU firmware update](robot#firmware-update)
     </TabItem>
     <TabItem value="Ridgeback">
         Ridgeback R100 updates:
-        1. [MCU firmware update](/docs/ros/installation/robot#firmware-update)
+        1. [MCU firmware update](robot#firmware-update)
     </TabItem>
     <TabItem value="Warthog">
         Warthog W200 updates:
-        1. [MCU firmware update](/docs/ros/installation/robot#firmware-update)
+        1. [MCU firmware update](robot#firmware-update)
     </TabItem>
 </Tabs>

--- a/docs_versioned_docs/version-ros2jazzy/ros/installation/updates.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/installation/updates.mdx
@@ -9,6 +9,16 @@ toc_max_heading_level: 4
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
+:::note
+
+This page explains how to install updates on a robot that is already running ROS 2 Jazzy
+on Ubuntu 24.04.
+
+If your robot is running an older version of ROS, please refer to our
+[upgrade page](upgrading).
+
+:::
+
 ## Updating Debian Packages
 
 Most software on your robot is installed as **debian packages** managed by Ubuntu. To update

--- a/docs_versioned_docs/version-ros2jazzy/ros/installation/updates.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/installation/updates.mdx
@@ -103,7 +103,7 @@ firmware update process for your Clearpath platform:
 <Tabs>
     <TabItem value="Husky A300" default>
         Husky A300 updates:
-        1. [MCU firmware update](/docs_robots/outdoor_robots/husky/a300/maintenance_husky#mcu_firmware_update)
+        1. [MCU firmware update](/docs/ros/installation/robot#firmware-update)
         2. [Motor controller firmware update](/docs_robots/outdoor_robots/husky/a300/maintenance_husky#maintenance_husky_motor_controller_firmware)
     </TabItem>
     <TabItem value="Husky A200">
@@ -113,22 +113,22 @@ firmware update process for your Clearpath platform:
     </TabItem>
     <TabItem value="Jackal">
         Jackal J100 updates:
-        1. [MCU firmware update](/docs_robots/outdoor_robots/jackal/maintenance_jackal#mcu-firmware-update)
+        1. [MCU firmware update](/docs/ros/installation/robot#firmware-update)
     </TabItem>
-    <TabItem value="Dingo D150">
+    <TabItem value="Dingo DX150">
         Dingo DO150 and DD150 updates:
-        1. [MCU firmware update](/docs_robots/indoor_robots/dingo/maintenance_dingo#mcu-firmware-update)
+        1. [MCU firmware update](/docs/ros/installation/robot#firmware-update)
     </TabItem>
-    <TabItem value="Dingo D100">
+    <TabItem value="Dingo DX100">
         Dingo DO100 and DD100 updates:
-        1. [MCU firmware update](/docs_robots/indoor_robots/dingo/maintenance_dingo#mcu-firmware-update)
+        1. [MCU firmware update](/docs/ros/installation/robot#firmware-update)
     </TabItem>
     <TabItem value="Ridgeback">
         Ridgeback R100 updates:
-        1. [MCU firmware update](/docs_robots/indoor_robots/ridgeback/maintenance_ridgeback#mcu-firmware-update)
+        1. [MCU firmware update](/docs/ros/installation/robot#firmware-update)
     </TabItem>
     <TabItem value="Warthog">
         Warthog W200 updates:
-        1. [MCU firmware update](/docs_robots/outdoor_robots/warthog/maintenance_warthog#mcu-firmware-update)
+        1. [MCU firmware update](/docs/ros/installation/robot#firmware-update)
     </TabItem>
 </Tabs>

--- a/docs_versioned_docs/version-ros2jazzy/ros/installation/upgrading.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/installation/upgrading.mdx
@@ -1,7 +1,7 @@
 ---
 title: Upgrading to Jazzy
 sidebar_label: Upgrading to Jazzy
-sidebar_position: 1
+sidebar_position: 2
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 ---
@@ -130,7 +130,7 @@ back these up yourself; `backup.sh` will not do this for you.
 ## Converting Environment Variables to Clearpath Config
 
 The environment variables used to define your robot in ROS 1 and ROS 2 Foxy can be converted to the `robot.yaml`
-format to maintain the same robot description when you upgrade to ROS 2 Jazzy. 
+format to maintain the same robot description when you upgrade to ROS 2 Jazzy.
 Below are some common examples. Visit the [robot.yaml documentation](../config/yaml/overview.mdx) for more details.
 If upgrading from ROS 2 Humble, keep a copy of your `robot.yaml` for use with ROS 2 Jazzy.
 

--- a/docs_versioned_docs/version-ros2jazzy/ros/installation/upgrading.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/installation/upgrading.mdx
@@ -11,6 +11,16 @@ import TabItem from "@theme/TabItem";
 
 :::note
 
+This page explains how to upgrade a robot running an older version of ROS (e.g. Noetic or Humble)
+to ROS 2 Jazzy.
+
+If your robot is already running ROS 2 Jazzy on Ubuntu 24.04, please refer to our
+[updates page](updates) for instructions on how to install the latest updates for Jazzy.
+
+:::
+
+:::note
+
 Users who are installing ROS 2 Jazzy onto a new robot computer can skip to [Robot Installation](robot.mdx).
 
 :::


### PR DESCRIPTION
Currently there's nothing in the software section to cover how to keep the robot up-to-date. Add a new page on installing updates with links to firmware update procedures