### PR TITLE
Add a note specifying the default location for `robot.yaml`.

### DIFF
--- a/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/overview.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/overview.mdx
@@ -6,9 +6,18 @@ toc_min_heading_level: 2
 toc_max_heading_level: 4
 ---
 
-Our robots provide users with a wide range of customization options: sensors, sensor mounting structures, and custom-made parts. Matching the flexibility of our hardware, Clearpath's ROS 2 system is designed to keep all these customization decisions in a single configuration file.
+:::note
 
-The **Clearpath Robot Configuration YAML**, or `robot.yaml` for short, contains all pertinent information to the entire robot system, allowing robot builders and users to quickly and easily modify any ROS 2 component.
+By default `robot.yaml` is located at `/etc/clearpath/robot.yaml`.
+
+:::
+
+Our robots provide users with a wide range of customization options: sensors, sensor mounting structures,
+and custom-made parts. Matching the flexibility of our hardware, Clearpath's ROS 2 system is designed
+to keep all these customization decisions in a single configuration file.
+
+The **Clearpath Robot Configuration YAML**, or `robot.yaml` for short, contains all pertinent information
+to the entire robot system, allowing robot builders and users to quickly and easily modify any ROS 2 component.
 
 ## Outline
 


### PR DESCRIPTION
Support mentioned that there was no absolute path mentioned on this page, so let's add it in an obvious note at the top of the page.