### PR TITLE
Fix headers for supported sensors, manipulators

### DIFF
--- a/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/manipulators.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/manipulators.mdx
@@ -20,7 +20,9 @@ Additionally, MoveIt! must be launched to plan paths and move manipulators to a 
 
 Every arm can have at most one gripper, and grippers can only be added to an existing arm. This way, depending on the arm and the gripper, the configuration system can determine whether the arm handles communication with the gripper or whether it must be done through an external connection directly to the robot computer.
 
-## Kinova Arms {#kinova-arms}
+## Supported Manipulators
+
+### Kinova Arms {#kinova-arms}
 <KinovaGen3Lite/>
 <br/>
 
@@ -30,17 +32,17 @@ Every arm can have at most one gripper, and grippers can only be added to an exi
 <KinovaGen37Dof/>
 <br/>
 
-## Kinova Grippers {#kinova-grippers}
+### Kinova Grippers {#kinova-grippers}
 <Kinova2FLite/>
 <br/>
 
-## Robotiq Grippers {#robotiq-grippers}
+### Robotiq Grippers {#robotiq-grippers}
 <Robotiq2F85/>
 <br/>
 
 <Robotiq2F140/>
 <br/>
 
-## Universal Robots {#universal-robots}
+### Universal Robots {#universal-robots}
 <UniversalRobots/>
 <br/>

--- a/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/sensors/charger.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/sensors/charger.mdx
@@ -9,5 +9,7 @@ import Wiferion from "/docs_versioned_docs/version-ros2jazzy/components/yaml/sen
 
 Wireless battery chargers are necessary attachments for a fully autonomous, self docking robot platform. These devices incorporate sensors that determine the quality of the charging position and orientation, status of the charging coil, and status of the stationary unit.
 
-## Wiferion Wireless Charger
+## Supported Chargers
+
+### Wiferion Wireless Charger
 <Wiferion/>

--- a/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/sensors/gps.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/sensors/gps.mdx
@@ -12,14 +12,16 @@ import SwiftNavDuro from "/docs_versioned_docs/version-ros2jazzy/components/yaml
 
 GPS (aka: GNSS) receivers are all devices that publish a `sensor_msgs/NavSatFix` message, which provides a latitude and longitude position.
 
-## SwiftNav Duro
+## Supported GPS Sensors
+
+### SwiftNav Duro
 <SwiftNavDuro/>
 
-## Garmin 18X
+### Garmin 18X
 <Garmin18x/>
 
-## Novatel Smart6
+### Novatel Smart6
 <NovatelSmart6/>
 
-## Novatel Smart7
+### Novatel Smart7
 <NovatelSmart7/>

--- a/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/sensors/imu.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/sensors/imu.mdx
@@ -11,11 +11,13 @@ import MicrostrainIMU from "/docs_versioned_docs/version-ros2jazzy/components/ya
 
 Inertial measurement units are sensors that publish messages of the type `sensor_msgs/Imu`. These messages contain orientation, angular velocity, and/or linear acceleration depending on the device.
 
-## Microstrain IMU
+## Supported IMUs
+
+### Microstrain IMU
 <MicrostrainIMU/>
 
-## CHRobotics UM6
+### CHRobotics UM6
 <CHRoboticsUM6/>
 
-## Redshift UM7
+### Redshift UM7
 <RedShiftUM7/>

--- a/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/sensors/ins.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/sensors/ins.mdx
@@ -13,6 +13,8 @@ can be augmented with GNSS and/or visual data for more precise outputs.
 INS may publish a variety of data, including `sensor_msgs/msg/Imu`,
 `sensor_msgs/msg/NavSatFix`, and `nav_msgs/msg/Odometry` types.
 
-## Fixposition Vision-RTK 2
+## Supported INS Sensors
+
+### Fixposition Vision-RTK 2
 
 <FixpositionXVN/>

--- a/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/sensors/lidar2d.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/sensors/lidar2d.mdx
@@ -10,8 +10,10 @@ import SickLMS1xx from "/docs_versioned_docs/version-ros2jazzy/components/yaml/s
 
 Two dimensional LiDARs provide a single planar scan, which is pusblished as a `sensor_msgs/LaserScan` message. It is important to accurately position the scanner in the visual description of the robot to ensure that the scanned plane is accurate with respect to the robot.
 
-## Hokuyo UST
+## Supported 2D Lidars
+
+### Hokuyo UST
 <HokuyoUST/>
 
-## SICK LMS1xx
+### SICK LMS1xx
 <SickLMS1xx/>

--- a/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/sensors/lidar3d.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/sensors/lidar3d.mdx
@@ -11,11 +11,13 @@ import VelodyneLidar from "/docs_versioned_docs/version-ros2jazzy/components/yam
 
 Three dimensional LiDARs provide a pointcloud of all points detected by several planar scanners at various angles, which is published as a `sensor_msgs/PointCloud2` message. It is important to accurately position the LiDAR in the visual descriptiuon of the robot to ensured that the scanned points are accurate with respect to the robot.
 
-## Ouster OS1
+## Supported 3D Lidars
+
+### Ouster OS1
 <OusterLidar />
 
-## Seyond Robin W
+### Seyond Robin W
 <SeyondLidar />
 
-## Velodyne Lidar
+### Velodyne Lidar
 <VelodyneLidar/>


### PR DESCRIPTION
The `component` pages assume each individual sensors heading is at H3 level, but several were at H2. Add a new H2 "Supported ____" header for all sections, and push individual devices to H3 so the section numbering is consistent.