### PR TITLE
Re-order the launch items for the Nav2 tutorials

### DIFF
--- a/docs_versioned_docs/version-ros2jazzy/ros/tutorials/navigation_demos/localization.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/tutorials/navigation_demos/localization.mdx
@@ -29,12 +29,11 @@ to `false`.
 
 :::
 
-**1.** [Start the simulation and Nav2](nav2.mdx#launching-the-simulation-and-nav2)
-by following steps 1-3 of the Nav2 startup
-
-**2.** Open a terminal and run
+To start localization using [AMCL](https://docs.nav2.org/configuration/packages/configuring-amcl.html)
+[follow the steps](nav2.mdx#launching-the-simulation-and-nav2) described in the Nav2
+startup. When you get to step 4, run
 ```bash
-ros2 launch clearpath_nav2_demos localization.launch.py use_sim_time:=true
+ros2 launch clearpath_nav2_demos localiztion.launch.py use_sim_time:=true
 ```
 
 The default map used by `localization.launch.py` is a
@@ -43,8 +42,3 @@ If you are using a custom map, pass it in with the `map` launch argument:
 ```bash
 ros2 launch clearpath_nav2_demos localization.launch.py use_sim_time:=true map:=/path/to/my/map.yaml
 ```
-
-**3.** [Start Rviz](nav2.mdx#launching-the-simulation-and-nav2) and set the robot's initial pose
-estimate by following steps 5-6 of the Nav2 startup
-
-**4.** Give the robot a navigation goal using the [Nav2 Goal](nav2.mdx#nav2-goal) tool.

--- a/docs_versioned_docs/version-ros2jazzy/ros/tutorials/navigation_demos/nav2.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/tutorials/navigation_demos/nav2.mdx
@@ -30,22 +30,22 @@ ros2 launch clearpath_gz simulation.launch.py
 
 If the simulation does not start automatically, press the large orange "play" button in the bottom left corner.
 
-**3.** Open a second terminal and launch nav2:
-
+**3.** Open a second terminal and start Rviz. If you are using a physical robot or running the simulation
+on an external server, this step must be should on your workstation, not on the robot or simulation server itself.
 ```
-ros2 launch clearpath_nav2_demos nav2.launch.py use_sim_time:=true
+ros2 launch clearpath_viz view_navigation.launch.py namespace:=a300_0000 use_sim_time:=true
 ```
 
 **4.** Open a third terminal and start either [SLAM](slam.mdx) or [Localization](localization.mdx), depdending on
 whether or not you want to create a new map or use a pre-existing map.
 
-**5.** Open a fourth terminal and start Rviz. If you are using a physical robot or running the simulation
-on an external server, this step must be should on your workstation, not on the robot or simulation server itself.
-```
-ros2 launch clearpath_viz view_navigation.launch.py namespace:=a300_0000
-```
+**5.** Set the initial pose of the robot using the [**2D Pose Estimate**](#2d-pose-estimate) tool in RViz.
 
-**6.** Set the initial pose of the robot using the [**2D Pose Estimate**](#2d-pose-estimate) tool in RViz.
+**6.** Open fourth second terminal and launch nav2:
+
+```
+ros2 launch clearpath_nav2_demos nav2.launch.py use_sim_time:=true
+```
 
 **7.** Give the robot a navigation goal using the [**Nav2 Goal**](#nav2-goal) tool in RViz.
 

--- a/docs_versioned_docs/version-ros2jazzy/ros/tutorials/navigation_demos/slam.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/tutorials/navigation_demos/slam.mdx
@@ -32,18 +32,15 @@ to `false`.
 
 :::
 
-**1.** [Start the simulation and Nav2](nav2.mdx#launching-the-simulation-and-nav2)
-by following steps 1-3 of the Nav2 startup
-
-**2.** Open a terminal and run
+To start SLAM, [follow the steps](nav2.mdx#launching-the-simulation-and-nav2) described in the Nav2
+startup. When you get to step 4, run
 ```bash
 ros2 launch clearpath_nav2_demos slam.launch.py use_sim_time:=true
 ```
 
-**3.** [Start Rviz](nav2.mdx#launching-the-simulation-and-nav2) and set the robot's initial pose
-estimate by following steps 5-6 of the Nav2 startup
+### Building the map
 
-**4.** Drive the robot around the world. Ensure you have mapped the region you want the robot
+Drive the robot around the world. Ensure you have mapped the region you want the robot
 to navigate through autonomously.
 
 <center>
@@ -56,10 +53,10 @@ to navigate through autonomously.
   </figure>
 </center>
 
-**5.** Save the map by opening a new terminal and running
+### Saving the map
+
+To save the map, open a new terminal and run
 ```bash
 ros2 run nav2_map_server map_saver_cli -f "map_name"
 --ros-args -p map_subscribe_transient_local:=true -r __ns:=/a300_0000
 ```
-
-**6.** Give the robot a navigation goal using the [Nav2 Goal](nav2.mdx#nav2-goal) tool.


### PR DESCRIPTION
Re-order the launch items for the Nav2 tutorials; the previous order appeared unreliable.

Resolves issues reported in https://github.com/clearpathrobotics/clearpath_nav2_demos/issues/29