### PR TITLE
Jackal heading indenture

### DIFF
--- a/docs_robots/outdoor_robots/jackal/integration_jackal.mdx
+++ b/docs_robots/outdoor_robots/jackal/integration_jackal.mdx
@@ -20,7 +20,7 @@ supply, and software integration. This guide aims to equip you with respect to t
 ## Mechanical Mounting
 
 When determining mechanical mounting, you can use the Standard square mounting pattern on the lid of the Jackal.
-At this time, the "PACS&trade;" mounting system is not available for Jackal.
+At this time, the [PACS&trade;](../../accessories/pacs) mounting system is not available for Jackal.
 
 ### Mechanical, Standard
 

--- a/docs_robots/outdoor_robots/jackal/integration_jackal.mdx
+++ b/docs_robots/outdoor_robots/jackal/integration_jackal.mdx
@@ -17,12 +17,12 @@ supply, and software integration. This guide aims to equip you with respect to t
 
 ---
 
-### Mechanical Mounting
+## Mechanical Mounting
 
 When determining mechanical mounting, you can use the Standard square mounting pattern on the lid of the Jackal.
 At this time, the "PACS&trade;" mounting system is not available for Jackal.
 
-#### Mechanical, Standard
+### Mechanical, Standard
 
 A standard Jackal is delivered with a 120 mm square mounting pattern of M5×0.8 threaded holes on its lid, which can be
 used for attaching external payloads. The mounting holes come with M5 thumbscrews pre-installed.
@@ -45,11 +45,11 @@ While Jackal does not support [PACS&trade;](../../accessories/pacs) directly, th
   :::
 - [OutdoorNav Starter Kit](../../accessories/add-ons/outdoornav_starter_kit.mdx)
 
-### Electrical Integration {#jackal-payload-electrical-integration}
+## Electrical Integration {#jackal-payload-electrical-integration}
 
 Except for bus-powered USB cameras, most payloads have separate leads for power and data.
 
-#### Data Connections
+### Data Connections
 
 Data connections may be brought through the hatch and connected directly to the internal computer. Both
 of Jackal's internal computer options support USB3 and Ethernet connectivity. With the performance
@@ -58,7 +58,7 @@ computer, the PCIe slot may be used to supply Firewire, Thunderbolt, or addition
 Additionally, the internal mounting area may be used for an Ethernet switch, when attaching multiple
 Ethernet payloads, or for a PoE power injector as required.
 
-#### Connector Summary
+### Connector Summary
 
 The Jackal User Power Board (UPB) board provides a number of connections for power.
 These are summarized in the following table and described in more detail in the following sections.
@@ -85,7 +85,7 @@ These are summarized in the following table and described in more detail in the 
   </figure>
 </center>
 
-#### User Power Connections
+### User Power Connections
 
 Similar to the data connections, power leads may be brought through the hatch, and connected to the User Power Board.
 The following are available as user power:
@@ -105,7 +105,7 @@ pin does not exceed 8 A.
 
 :::
 
-#### MCU Debug LEDs
+### MCU Debug LEDs
 
 The Jackal MCU circuit board comes equipped with four LEDs controlled by Jackal firmware for debugging.
 If the system is working properly, these LEDs function as follows:


### PR DESCRIPTION
The Jackal's Integration page has a CSS autonumbering issue. This update makes the page start counting from 1, rather than 0.1