### PR TITLE
Husky A200 STEP model, updating the track width

### DIFF
--- a/components/husky_a200/husky_a200_step_model.mdx
+++ b/components/husky_a200/husky_a200_step_model.mdx
@@ -3,7 +3,7 @@ import ComponentButtonStepDownload from "/components/button_download_step.tsx";
 ### STEP Model {#step-model}
 
 <div>
-  <ComponentButtonStepDownload filePath={"https://cpr-documentation-large-files.s3.us-east-2.amazonaws.com/034991-GEO_1.STEP"}/>
+  <ComponentButtonStepDownload filePath={"https://cpr-documentation-large-files.s3.us-east-2.amazonaws.com/034991-GEO_2.STEP"}/>
 
 This simplified 3D model of the Husky A200 includes details like the internal
   battery, circuit board where you can connect to the robot's electrical 


### PR DESCRIPTION
Updated the hyperlink to the Husky A200's STEP model. The new model has wheels at 0.555 metres width, rather than the previous 0.55 m.