### PR TITLE
Feature: Zenoh and Cyclone DDS Remote Computer Setups

### DIFF
--- a/components/supported_platforms.mdx
+++ b/components/supported_platforms.mdx
@@ -22,18 +22,18 @@ middleware implementations other than `Fast DDS`.
 
 If you need your Clearpath robot to interact with systems that rely on unsupported middleware, please
 refer to [ROS' middleware documentation](https://docs.ros.org/en/jazzy/Concepts/Intermediate/About-Different-Middleware-Vendors.html)
-for information on cross-vendor commuication.
+for information on cross-vendor communication.
 
 :::
 
-| Platform  | Platform code | Fast DDS    | CycloneDDS | Connext DDS | GurumDDS | Zenoh     |
-|:--------- |:------------- |:----------- |:---------- |:----------- |:-------- | :-------- |
-| Husky     | A200          | Yes         | Yes        | No          | No       | Yes       |
-|           | A300          | Yes         | No         | No          | No       | No        |
-| Jackal    | J100          | Yes         | No         | No          | No       | No        |
-| Warthog   | W200          | Yes         | No         | No          | No       | No        |
-| Dingo     | DD100         | Yes         | No         | No          | No       | No        |
-|           | DO100         | Yes         | No         | No          | No       | No        |
-|           | DD150         | Yes         | No         | No          | No       | No        |
-|           | DO150         | Yes         | No         | No          | No       | No        |
-| Ridgeback | R100          | Yes         | No         | No          | No       | No        |
+| Platform  | Platform code | Fast DDS    | CycloneDDS      | Connext DDS | GurumDDS | Zenoh           |
+|:--------- |:------------- |:----------- |:--------------- |:----------- |:-------- | :-------------- |
+| Husky     | A200          | Yes         | Yes             | No          | No       | Yes             |
+|           | A300          | Yes         | Yes (as of 2.9) | No          | No       | Yes (as of 2.9) |
+| Jackal    | J100          | Yes         | Yes (as of 2.9) | No          | No       | Yes (as of 2.9) |
+| Warthog   | W200          | Yes         | Yes (as of 2.9) | No          | No       | Yes (as of 2.9) |
+| Dingo     | DD100         | Yes         | Yes (as of 2.9) | No          | No       | Yes (as of 2.9) |
+|           | DO100         | Yes         | Yes (as of 2.9) | No          | No       | Yes (as of 2.9) |
+|           | DD150         | Yes         | Yes (as of 2.9) | No          | No       | Yes (as of 2.9) |
+|           | DO150         | Yes         | Yes (as of 2.9) | No          | No       | Yes (as of 2.9) |
+| Ridgeback | R100          | Yes         | Yes (as of 2.9) | No          | No       | Yes (as of 2.9) |

--- a/docs_versioned_docs/version-ros2jazzy/components/networking/_ros2_networking_overview.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/components/networking/_ros2_networking_overview.mdx
@@ -9,6 +9,6 @@ Each of these discovery mechanisms has their own use case:
 - Good for simple systems (small number of nodes on a dedicated local network)
 
 **Discovery Server**
-- Requires [manual configuration](/docs/ros/networking/ros2_networking/ros2_discovery_config#discovery-server-configurations) in `robot.yaml`
+- Requires [manual configuration](/docs/ros/networking/ros2_networking/fast_configuration#discovery-server-configurations) in `robot.yaml`
 - Generally operates on the basis that ROS 2 networks should be controlled and should only discover other nodes as needed
 - Does not require multicasting (more likely to work on school or corporate networks)

--- a/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/platform/mcu.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/platform/mcu.mdx
@@ -8,13 +8,13 @@ toc_max_heading_level: 5
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-Since the `Jazzy 2.9` (and `firmware 3.0`) release, the communication between the robot's MCU and computer has been updated to the Proton protocol. Proton is a _protobuf_ based communication protocol that is ROS agnostic (and ROS middleware agnostic). Therefore to use middlewares other than Fast DDS on Clearpath platforms, the robot's MCU firmware must be at least version `3.0`.
+Since the `Jazzy 2.9` (and `firmware 3.0.0`) release, the communication between the robot's MCU and computer has been updated to the Proton protocol. Proton is a _protobuf_ based communication protocol that is ROS agnostic (and ROS middleware agnostic). Therefore to use middlewares other than Fast DDS on Clearpath platforms, the robot's MCU firmware must be at least version `3.0.0`.
 
 On all Clearpath platforms, the robot's computer needs to launch a base node to establish communication with the robot's MCU:
-- When using MCU firmware `2.8` or older, the base node is a micro-ROS node, on all platforms other than the Husky A200.
-- With the introduction of Proton, all robots with MCU firmware `3.0` or newer, use a Proton node as the base node.
+- When using MCU firmware `2.7` or older, the base node is a micro-ROS node, on all platforms other than the Husky A200.
+- With the introduction of Proton, all robots with MCU firmware `3.0.0` or newer, use a Proton node as the base node.
 
-For the purposes of maintaining backward compatibility, the default protocol will remain micro-ROS (`uros`), but users with new robots or that have upgraded their robot's firmware to `3.0`, will need to set the protocol to Proton (`proton`) in the Clearpath configuration file, `robot.yaml`.
+For the purposes of maintaining backward compatibility, the default protocol will remain micro-ROS (`uros`), but users with new robots or that have upgraded their robot's firmware to `3.0.0`, will need to set the protocol to Proton (`proton`) in the Clearpath configuration file, `robot.yaml`.
 
 <Tabs groupId="MCU Protocols">
 <TabItem value="Proton" label="Proton" default>
@@ -28,7 +28,7 @@ platform:
 
 :::warning
 
-The Proton protocol is required when using firmware version `3.0`. If firmware is older (e.g. 2.7 or older), use `uros` instead.
+The Proton protocol is required when using firmware version `3.0.0`. If firmware is older (e.g. 2.7 or older), use `uros` instead.
 
 :::
 
@@ -44,7 +44,7 @@ platform:
 
 :::warning
 
-The micro-ROS protocol is required when using firmware version `2.7` or older. If firmware version is newer than `3.0`, use `proton` instead.
+The micro-ROS protocol is required when using firmware version `2.7` or older. If firmware version is newer than `3.0.0`, use `proton` instead.
 
 :::
 

--- a/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/system.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/system.mdx
@@ -55,50 +55,70 @@ ros2:
 ### Middleware
 
 The **middleware** section defines the which RMW Implementation to use and any related settings. To choose
-which implementation and discovery method is right for your project see [ROS 2 Discovery Configuration](../../networking/ros2_networking/ros2_discovery_config.mdx).
+which implementation and discovery method is right for your project see [ROS 2 Discovery Configuration](../../networking/ros2_networking/fast_configuration.mdx).
 
 :::note
 
-All platforms can use `rmw_fastrtps_cpp`.
+When using firmware version `2.7` or older, platforms, other than the Husky A200, use `rmw_fastrtps_cpp`. Attempting to use Zenoh on any other platform will result in an error when processing `robot.yaml`.
 
-Currently only the Husky A200 can use `rmw_zenoh_cpp`. Attempting to use Zenoh on any other platform will result in an error when processing `robot.yaml`.
+When using firmware version `3.0` or later (released of the `Jazzy 2.9 version`), all platforms can use any middleware as long as it is installed on the robot's computer. However, the robot's computer must use the Proton MCU protocol. Set the MCU protocol as outlined in the [platform documentation](./platform/mcu.mdx)
 
 :::
 
 | Key | Value / Datatype | Description |
 |:---:| :--------------: | ----------- |
-| **implementation** | string               | Declares the RMW Implementation to use. Currently only supports `rmw_fastrtps_cpp` and `rmw_zenoh_cpp`. |
+| **implementation** | string               | Declares the RMW Implementation to use. As of firmware version `3.0` supports, Clerpath platforms can use all middlewares, but Clearpath primarily supports the `rmw_cyclonedds_cpp`, `rmw_fastrtps_cpp`, and `rmw_zenoh_cpp` middlewares. |
 | **discovery**      | `simple` or `server` | Select `simple` for simple discovery and `server` for discovery server. (Defaults to `simple`. Ignored if `implementation` is not `rmw_fastrtps_cpp`.) |
 | **profile**        | string               | Advanced feature, allows an optional custom profile to be provided - RMW Implementation / vendor specific. |
 | **servers**        | list                 | Provides a list of all discovery servers in the system and whether or not the robot should connect to them. Ignored if `implementation` is not `rmw_fastrtps_cpp`.|
 | **automatic_discovery_range** | string    | Sets the value for the `ROS_AUTOMATIC_DISCOVERY_RANGE` environment variable. Must be one of `subnet`, `localhost`, `system_default`, or `off`. |
 | **static_peers**   | list                 | List of IP addresses or hostnames that ROS should discover nodes on. Sets the value of the `ROS_STATIC_PEERS` environment variable. |
 
-For example:
+#### Fast DDS Example:
 
 ```yaml
-middleware:
-  implementation: rmw_fastrtps_cpp
-  discovery: simple
-  automatic_discovery_range: subnet
-  static_peers:
-    - 192.168.131.1
-    - 192.168.131.2
-  profile: path/to/profile.xml
-  servers: # This section is described further below
-    - hostname: cpr-a200-0000
+system:
+  ros2:
+    middleware:
+      implementation: rmw_fastrtps_cpp
+      discovery: simple
+      automatic_discovery_range: subnet
+      static_peers:
+        - 192.168.131.1
+        - 192.168.131.2
+      profile: path/to/profile.xml
+      servers: # This section is described further below
+        - hostname: cpr-a200-0000
 ```
 
-Second example, using Zenoh:
+#### Zenoh Example:
 
 ```yaml
-middleware:
-  implementation: rmw_zenoh_cpp
-  profile: /path/to/router_configuration.json5
+system:
+  ros2:
+    middleware:
+      implementation: rmw_zenoh_cpp
+      profile: /path/to/router_configuration.json5
 
-  servers: # This section is described further below
-    - hostname: cpr-a200-0000
+      servers: # This section is described further below
+        - hostname: cpr-a200-0000
 ```
+
+#### Cyclone DDS Example:
+
+```yaml
+system:
+  ros2:
+    middleware:
+      implementation: rmw_cyclonedds_cpp
+  bash:
+    env:
+      CYCLONEDDS_URI: /home/robot/.cyclone/profile.xml
+```
+:::note
+The Cyclone Profile XML is not required for the robot's nodes to communicate with each other, but for using a remote computer to communicate with the robot's computer, it will need to be configured. See the documentation on configuring the [Cyclone Profile XML for remote communication](../../networking/ros2_networking/cyclone.mdx) for more information.
+:::
+
 
 #### Servers
 

--- a/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/system.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/system.mdx
@@ -61,13 +61,13 @@ which implementation and discovery method is right for your project see [ROS 2 D
 
 When using firmware version `2.7` or older, platforms, other than the Husky A200, use `rmw_fastrtps_cpp`. Attempting to use Zenoh on any other platform will result in an error when processing `robot.yaml`.
 
-When using firmware version `3.0` or later (released of the `Jazzy 2.9 version`), all platforms can use any middleware as long as it is installed on the robot's computer. However, the robot's computer must use the Proton MCU protocol. Set the MCU protocol as outlined in the [platform documentation](./platform/mcu.mdx)
+When using firmware version `3.0.0` or later (released of the `Jazzy 2.9 version`), all platforms can use any middleware as long as it is installed on the robot's computer. However, the robot's computer must use the Proton MCU protocol. Set the MCU protocol as outlined in the [platform documentation](./platform/mcu.mdx)
 
 :::
 
 | Key | Value / Datatype | Description |
 |:---:| :--------------: | ----------- |
-| **implementation** | string               | Declares the RMW Implementation to use. As of firmware version `3.0` supports, Clerpath platforms can use all middlewares, but Clearpath primarily supports the `rmw_cyclonedds_cpp`, `rmw_fastrtps_cpp`, and `rmw_zenoh_cpp` middlewares. |
+| **implementation** | string               | Declares the RMW Implementation to use. As of firmware version `3.0.0` supports, Clearpath platforms can use all middlewares, but Clearpath primarily supports the `rmw_cyclonedds_cpp`, `rmw_fastrtps_cpp`, and `rmw_zenoh_cpp` middlewares. |
 | **discovery**      | `simple` or `server` | Select `simple` for simple discovery and `server` for discovery server. (Defaults to `simple`. Ignored if `implementation` is not `rmw_fastrtps_cpp`.) |
 | **profile**        | string               | Advanced feature, allows an optional custom profile to be provided - RMW Implementation / vendor specific. |
 | **servers**        | list                 | Provides a list of all discovery servers in the system and whether or not the robot should connect to them. Ignored if `implementation` is not `rmw_fastrtps_cpp`.|

--- a/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/system.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/config/yaml/system.mdx
@@ -57,7 +57,7 @@ ros2:
 The **middleware** section defines the which RMW Implementation to use and any related settings. To choose
 which implementation and discovery method is right for your project see [ROS 2 Discovery Configuration](../../networking/ros2_networking/fast_configuration.mdx).
 
-:::note
+:::warning
 
 When using firmware version `2.7` or older, platforms, other than the Husky A200, use `rmw_fastrtps_cpp`. Attempting to use Zenoh on any other platform will result in an error when processing `robot.yaml`.
 

--- a/docs_versioned_docs/version-ros2jazzy/ros/installation/offboard_pc.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/installation/offboard_pc.mdx
@@ -95,4 +95,4 @@ Add the following line to your `~/.bashrc` file to automatically source the gene
 source ~/clearpath/setup.bash
 ```
 
-4. If you are using Fast DDS Discovery Server, follow the instructions on [ROS 2 Discovery Configuration](../networking/ros2_networking/ros2_discovery_config.mdx#offboard-pc).
+4. If you are using Fast DDS Discovery Server, follow the instructions on [ROS 2 Discovery Configuration](../networking/ros2_networking/fast_configuration.mdx#offboard-pc).

--- a/docs_versioned_docs/version-ros2jazzy/ros/networking/network_troubleshooting/intermittent_connectivity.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/networking/network_troubleshooting/intermittent_connectivity.mdx
@@ -38,7 +38,7 @@ The first step is to determine if the ROS 2 system is actually the problem. With
 
 If the ROS 2 system is responsible for most of the bandwidth then it is important to calculate the expected bandwidth usage of the ROS 2 system. Calculate the bandwidth required for each of the main topics that are being transmitted (largest sizes and highest frequency) to establish an estimate of the bandwidth required for the ROS 2 system operation. This can be calculated for each topic using `message size * frequency * number of subscriptions over the network`. For an example of this calculation for two computers, see the [Video over Wi-Fi](../../tutorials/video_over_wifi.mdx) tutorial. Compare this expected value with the measured value of how much bandwidth is being used by the ROS 2 system. If the actual bandwidth usage is double or higher than the expected bandwidth then consider that the system may be having the problem of [Duplicate Messages](#duplicate-messages).
 
-If the required bandwidth for the system exceeds the available bandwidth then changes must be made. The first thing to consider is if the data is being transmitted in the most concise or dense format. Refer to the discussion on the [ROS 2 Communication](../ros2_networking/ros2_communication.mdx#optimizing-sensor-data-for-transmission) page. Once the data is being transmitted using the most efficient message types, consider the frequency of the largest messages. Decreasing the frequency of messages directly reduces how much data needs to be processed and how much bandwidth is needed.
+If the required bandwidth for the system exceeds the available bandwidth then changes must be made. The first thing to consider is if the data is being transmitted in the most concise or dense format. Refer to the discussion on the [ROS 2 Communication](../ros2_networking/rmw_overview.mdx#optimizing-sensor-data-for-transmission) page. Once the data is being transmitted using the most efficient message types, consider the frequency of the largest messages. Decreasing the frequency of messages directly reduces how much data needs to be processed and how much bandwidth is needed.
 
 ## Duplicate Messages in Fast DDS {#duplicate-messages}
 
@@ -62,7 +62,7 @@ The following steps can be used to verify if this issue is present:
 
 1. The first solution is to ensure that the subscribing computer only ever connects to one network at a time and that it only has one IP address. This works well for initial testing and for situations where the networking configuration needs to change often. However, it must be monitored and managed every time the system is used. While this section refers to "the subscribing computer" this should be applied to every computer in the system that subscribes to any substantially sized data.
    1. Ensure that the subscribing computer is only connected to one network and therefore has only one IP address. In the example this would be the offboard computer.
-   2. Stop and restart all ROS nodes on the subscribing computer including the [ROS 2 Daemon](../ros2_networking/ros2_communication.mdx#ros-2-daemon) and any Discovery Servers on the offboard computer.
+   2. Stop and restart all ROS nodes on the subscribing computer including the [ROS 2 Daemon](../ros2_networking/rmw_overview.mdx#ros-2-daemon) and any Discovery Servers on the offboard computer.
    3. Confirm using the same [verification steps](#duplicate-verification) to ensure that the problem has been resolved.
 
 2. The second solution is more involved initially but can be set and forgotten. This solution works for systems where the networks are well defined and rarely change. As a reminder, the implementation details for this solution are specific to Fast DDS. The modification is to set a Fast DDS profile on the computer that restricts the locator list to a specific network interface using the IP address to identify the interface. This profile must be applied for all nodes as well as for the terminals.
@@ -107,7 +107,7 @@ The Max Message Size is set in this profile example because it is set by default
     export FASTDDS_DEFAULT_PROFILES_FILE=/path/to/file/fastdds_network_profile.xml
     ```
 
-      3. Stop and restart all ROS nodes on the subscribing computer including the [ROS 2 Daemon](../ros2_networking/ros2_communication.mdx#ros-2-daemon) and any Discovery Servers on the offboard computer.
+      3. Stop and restart all ROS nodes on the subscribing computer including the [ROS 2 Daemon](../ros2_networking/rmw_overview.mdx#ros-2-daemon) and any Discovery Servers on the offboard computer.
    3. Confirm using the same [verification steps](#duplicate-verification) to ensure that the problem has been resolved.
 
 
@@ -145,7 +145,7 @@ In Fast DDS this is done by applying the following XML profile. See the [Duplica
 
 ## Incorrect ROS 2 Quality of Service Settings {#qos}
 
-Subscriber quality of service settings such as reliability policy of *Reliable* or a large depth value can increase the network traffic and cause message backlogs in low bandwidth networks where some packets are lost. For more details, refer to the discussion on the [ROS 2 Communication](../ros2_networking/ros2_communication.mdx#qos) page.
+Subscriber quality of service settings such as reliability policy of *Reliable* or a large depth value can increase the network traffic and cause message backlogs in low bandwidth networks where some packets are lost. For more details, refer to the discussion on the [ROS 2 Communication](../ros2_networking/rmw_overview.mdx#qos) page.
 
 ## Insufficient Computing Resources
 

--- a/docs_versioned_docs/version-ros2jazzy/ros/networking/overview.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/networking/overview.mdx
@@ -72,7 +72,7 @@ For details on configuring `chrony`, please see [configuring NTP](ntp.mdx).
 ## ROS 2 Networking {#ros2-networking}
 
 There are many nuances to working with ROS 2 nodes and ensuring that all components are communicating properly. The most
-important of these concepts are reviewed in the [ROS 2 Communication](ros2_networking/ros2_communication.mdx) page.
+important of these concepts are reviewed in the [ROS 2 Communication](ros2_networking/fast_overview.mdx) page.
 
 :::tip
 
@@ -84,7 +84,7 @@ For the best chance of success, use a high speed, high bandwidth network and mon
 
 <Ros2NetworkingOverview/>
 
-Further information on [ROS 2 Discovery Configuration](ros2_networking/ros2_discovery_config.mdx).
+Further information on [ROS 2 Discovery Configuration](ros2_networking/fast_configuration.mdx).
 
 ## Network Troubleshooting
 

--- a/docs_versioned_docs/version-ros2jazzy/ros/networking/ros2_networking/cyclone.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/networking/ros2_networking/cyclone.mdx
@@ -1,0 +1,112 @@
+---
+title: Cyclone ROS Middleware
+sidebar_position: 5
+---
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+## Setting up the Cyclone Profile XML for Remote Computer Communication
+
+If the Clearpath robot has been set to use the Cyclone DDS ROS middleware (see the [middleware documentation on how to modify Clearpath's Configuration YAML](../../config/yaml/system.mdx#middleware)), it will be required to modify the Cyclone Profile XML to establish communication with a remote computer.
+
+For the robot Cyclone Profile XML, create a file on the robot computer's home directory: `/home/robot/.cyclone/profile.xml` and copy the contents of the sample robot profile below.
+
+For the user Cyclone Profile XML, create a file on the remote computer, preferably on the home directory: `$HOME/.cyclone/profile.xml` and copy the contents of the sample remote profile below.
+
+<Tabs groupId="profile.xml">
+<TabItem value="robot_profile" label="Robot Profile" default>
+
+1. If using a **wired connection** using the robot's ethernet port:
+
+    a. The remote computer must have a static IP assigned in the range `192.168.131.100 - 192.168.131.255`.
+
+    b. Replace the `REMOTE_IP` with the static IP assigned in the previous step.
+
+    c. The `ROBOT_INTERFACE` should then be replaced with `br0`, the robot's bridged interface.
+
+2. If using a **wireless connection** using a WiFi router:
+
+    a. The robot and remote computer must both be connected to a router and have been assigned an IP address by that router.
+
+    b. Replace the `REMOTE_IP` with the static IP assigned by the router to the remote computer. Use the `ip a` command on the remote computer to find the IP address assigned to it.
+
+    c. Replace the `ROBOT_INTERFACE` with the robot's WiFi interface, by default it should be `wlp2s0`, but it is recommended to check by using the `ip a` command on the remote computer to find if the interface has been renamed, in certain cases it could have been renamed to `wlp3s0`.
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<CycloneDDS xmlns="https://cdds.io/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://cdds.io/config https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd">
+    <Domain Id="any">
+        <General>
+            <Interfaces>
+                <NetworkInterface autodetermine="false" name="ROBOT_INTERFACE" />
+            </Interfaces>
+            <AllowMulticast>false</AllowMulticast>
+            <MaxMessageSize>65500B</MaxMessageSize>
+        </General>
+        <Discovery>
+            <EnableTopicDiscoveryEndpoints>true</EnableTopicDiscoveryEndpoints>
+        <ParticipantIndex>auto</ParticipantIndex>
+        <MaxAutoParticipantIndex>50</MaxAutoParticipantIndex>
+            <Peers>
+                <Peer Address="REMOTE_IP"/>
+                <Peer Address="127.0.0.1"/>
+            </Peers>
+        </Discovery>
+        <Internal>
+            <Watermarks>
+                <WhcHigh>500kB</WhcHigh>
+            </Watermarks>
+        </Internal>
+    </Domain>
+</CycloneDDS>
+```
+
+</TabItem>
+<TabItem value="remote_profile" label="Remote Profile" default>
+
+1. If using a **wired connection** using the robot's ethernet port:
+
+    a. Replace the `REMOTE_INTERFACE` with the name of the ethernet interface used by the remote computer. Use the `ip a` on the remote computer to find a list of the remote interfaces.
+
+    b. Replace the `ROBOT_IP` with the robot's static IP. By default, it will be set to `192.168.131.1`.
+
+2. If using a **wireless connection** using a WiFi router:
+
+    a. The robot and remote computer must both be connected to a router and have been assigned an IP address by that router.
+
+    b. Replace the `REMOTE_INTERFACE` with the remote computer's WiFi interface. Use the `ip a` command on the remote computer to get a list of all it's interfaces.
+
+    c. Replace the `ROBOT_IP` with the robot's WiFi IP address. Use the `ip a` command on the robot's computer to retrieve a list of all of it's interfaces. The IP address will be found under the wireless interface, by default it is named `wlp2s0`.
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<CycloneDDS xmlns="https://cdds.io/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://cdds.io/config https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd">
+    <Domain Id="any">
+        <General>
+            <Interfaces>
+                <NetworkInterface autodetermine="false" name="REMOTE_INTERFACE" />
+            </Interfaces>
+            <AllowMulticast>false</AllowMulticast>
+            <MaxMessageSize>65500B</MaxMessageSize>
+        </General>
+        <Discovery>
+            <EnableTopicDiscoveryEndpoints>true</EnableTopicDiscoveryEndpoints>
+        <ParticipantIndex>auto</ParticipantIndex>
+        <MaxAutoParticipantIndex>50</MaxAutoParticipantIndex>
+            <Peers>
+                <Peer Address="ROBOT_IP"/>
+                <Peer Address="127.0.0.1"/>
+            </Peers>
+        </Discovery>
+        <Internal>
+            <Watermarks>
+                <WhcHigh>500kB</WhcHigh>
+            </Watermarks>
+        </Internal>
+    </Domain>
+</CycloneDDS>
+```
+
+</TabItem>
+
+</Tabs>

--- a/docs_versioned_docs/version-ros2jazzy/ros/networking/ros2_networking/fast_configuration.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/networking/ros2_networking/fast_configuration.mdx
@@ -1,5 +1,5 @@
 ---
-title: ROS 2 Discovery Configuration
+title: Fast DDS Discovery Configuration
 sidebar_position: 3
 ---
 

--- a/docs_versioned_docs/version-ros2jazzy/ros/networking/ros2_networking/fast_overview.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/networking/ros2_networking/fast_overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: ROS 2 Networking
-sidebar_position: 1
+title: Fast DDS Overview
+sidebar_position: 2
 ---
 
 ## Overview
@@ -242,24 +242,3 @@ bash -e ~/clearpath/discovery-server-start
 ```
 
 
-## Zenoh Router
-
-In early 2025 a new ROS middleware implementation called **Zenoh** was released. For a
-detailed description of Zenoh, please refer to [Zenoh's design document](https://github.com/ros2/rmw_zenoh/blob/rolling/docs/design.md).
-
-Zenoh is only available on ROS 2 Jazzy and later; it cannot be used on ROS 2 Humble.
-
-### Starting the Zenoh Router
-
-To manually launch the Zenoh router run
-
-```bash
-bash -e ~/clearpath/zenoh-router-start
-```
-
-This process can also be daemonized and launched via the `systemctl` command:
-
-```bash
-source /opt/ros/jazzy/setup.bash
-sudo systemctl start clearpath-zenoh-router
-```

--- a/docs_versioned_docs/version-ros2jazzy/ros/networking/ros2_networking/rmw_overview.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/networking/ros2_networking/rmw_overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: ROS 2 Communication
-sidebar_position: 2
+title: Middleware and DDS Overview
+sidebar_position: 1
 ---
 
 This page reviews information that is useful to understand for working with ROS 2 DDS based communication.
@@ -8,7 +8,7 @@ This page reviews information that is useful to understand for working with ROS 
 ## RMW Implementations
 ROS 2 uses an abstracted [ROS Middleware](https://docs.ros.org/en/humble/Concepts/Intermediate/About-Different-Middleware-Vendors.html) (RMW) to manage the networking and communication. There are several RMW Implementations to choose from, and each operates somewhat differently. Most RMW Implementations are based on the [DDS](https://docs.ros.org/en/humble/Installation/DDS-Implementations.html) (Data Distribution Service) standard which is built on the RTPS (Real-time Publish Subscribe) protocol. In the DDS standard, the ROS 2 nodes act as participants that can publish and subscribe. In most cases, DDS uses UDP messages for the underlying communication over the network. Each RMW implementation has many ways that it can be configured to achieve different goals such as simplicity, redundancy or robustness. The DDS system is decentralized, meaning that the participants are not managed by any one entity. Instead the system works peer to peer, allowing nodes to find each other. This process is referred to as the discovery process.
 
-The Clearpath robot packages currently support the eProsima Fast DDS as the RMW Implementation. There are still several decisions that have to be made in configuring the Clearpath robot networking. The most significant decision is choosing the discovery method. In Fast DDS, there is the default `Simple Discovery` and the more managed `Discovery Server` option. These two options are discussed in detail in the [ROS 2 Discovery Config](ros2_discovery_config.mdx) page. Instructions on switching the discovery method are available on that page, as well as the specific parameters are documented in the [System section](../../config/yaml/system.mdx#middleware) of `robot.yaml`.
+The Clearpath robot packages currently support the eProsima Fast DDS as the RMW Implementation. There are still several decisions that have to be made in configuring the Clearpath robot networking. The most significant decision is choosing the discovery method. In Fast DDS, there is the default `Simple Discovery` and the more managed `Discovery Server` option. These two options are discussed in detail in the [ROS 2 Discovery Config](fast_configuration.mdx) page. Instructions on switching the discovery method are available on that page, as well as the specific parameters are documented in the [System section](../../config/yaml/system.mdx#middleware) of `robot.yaml`.
 
 ## DDS Settings
 There are a variety of settings that are set through the `robot.yaml` that control how the DDS layer operates. For example, the [Domain ID](https://docs.ros.org/en/humble/Concepts/Intermediate/About-Domain-ID.html) is used in the calculation of which ports each node communicates on. In order for the DDS communication to be successful, the network needs to allow unrestricted data flow between the devices on these ports.

--- a/docs_versioned_docs/version-ros2jazzy/ros/networking/ros2_networking/zenoh.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/networking/ros2_networking/zenoh.mdx
@@ -1,0 +1,65 @@
+---
+title: Zenoh ROS Middleware
+sidebar_position: 4
+---
+
+## Zenoh Router
+
+In early 2025 a new ROS middleware implementation called **Zenoh** was released. For a
+detailed description of Zenoh, please refer to [Zenoh's design document](https://github.com/ros2/rmw_zenoh/blob/rolling/docs/design.md).
+
+Zenoh is only available on ROS 2 Jazzy and later; it cannot be used on ROS 2 Humble. See the [documentation on the system section of the Clearpath configuration YAML](../../config/yaml/system.mdx#middleware) to set the middleware to Zenoh.
+
+### Automatically starting the Zenoh Router
+
+By setting the middleware in the system section of the Clearpath configuration file (found in the default Clearpath directory `/etc/clearpath/robot.yaml`), the Zenoh router start script is added to the generated `zenoh-router-start` script. This script is ran by the `clearpath-zenoh-router` service when the `clearpath-robot` service is started.
+
+### Manually starting the Zenoh Router
+
+Alternatively, if the service is not running or has been manually stopped, manually launch the Zenoh router run
+
+```bash
+bash -e ~/clearpath/zenoh-router-start
+```
+
+This process can also be daemonized and launched via the `systemctl` command:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+sudo systemctl start clearpath-zenoh-router
+```
+
+## Communicating with the Zenoh router from a remote computer
+
+When a user wants to connect a remote computer to communicate with the nodes running on the robot's computer using the Zenoh middleware, the user is recommended to follow these steps on the user's remote computer:
+1. Install the Zenoh ROS Middleware:
+```
+sudo apt update && sudo apt install ros-jazzy-rmw-zenoh-cpp
+```
+2. Set the Zenoh ROS Middleware in the environment:
+```
+export RMW_IMPLEMENTATION=rmw_zenoh_cpp
+```
+3. Connect the remote computer and robot computer to the same network.
+
+    a. **Wired Connection**: Connect the remote computer to the robot's ethernet port and set the remote computer's IP address in the range `192.168.131.100` to `192.168.131.255`.
+
+    b. **Wireless Connection**: Connect the robot computer to the same WiFi router as the remote computer. Find the IP address that the WiFi router assigned the robot's computer using the `ip a` command on a terminal on the robot's computer.
+
+4. Set the remote computer's Zenoh router configuration:
+
+    a. **Wired Connection**: Set the endpoint to the robot's static IP address (`192.168.131.1`):
+    ```
+    export ZENOH_CONFIG_OVERRIDE='mode="client";connect/endpoints=["tcp/192.168.131.1:7447"]'
+    ```
+
+    b. **Wireless Connection**: Set the endpoint to the robot's IP address assigned by the WiFi router:
+    ```
+    export ZENOH_CONFIG_OVERRIDE='mode="client";connect/endpoints=["tcp/ROBOT_WIFI_IP:7447"]'
+    ```
+
+5. Then make sure to restart the ROS2 daemon on the remote computer before using command line tools:
+```
+ros2 daemon stop
+ros2 topic list
+```

--- a/docs_versioned_docs/version-ros2jazzy/ros/ros.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/ros.mdx
@@ -304,7 +304,7 @@ contains the platform information, as well as the type and location of all of th
 sensors and manipulators.
 
 To add/remove/relocate sensors, change the robot's speed & acceleration parameters, change
-the [ROS Middleware](networking/ros2_networking/overview), or add custom launch files and nodes
+the [ROS Middleware](networking/ros2_networking/fast_overview), or add custom launch files and nodes
 to the startup services, edit this file:
 ```bash
 nano /etc/clearpath/robot.yaml

--- a/docs_versioned_docs/version-ros2jazzy/ros/troubleshooting.mdx
+++ b/docs_versioned_docs/version-ros2jazzy/ros/troubleshooting.mdx
@@ -208,7 +208,7 @@ each other it is advisable to assign each system a unique domain ID. This will m
 traffic, saving bandwidth and preventing nodes from accidentally communicating if they have topic
 names in common.
 
-See [ROS 2 communication](networking/ros2_networking/ros2_communication) for more information about
+See [ROS 2 communication](networking/ros2_networking/rmw_overview) for more information about
 configuring domain IDs.
 
 ## Mixing ROS 2 Humble and Jazzy


### PR DESCRIPTION
Add preliminary documentation to support Zenoh and Cyclone DDS middlewares. More extensive documentation will need to follow as we decide how extensively to support each middleware. 