### PR TITLE
RPSW-2903 customHttp.yml

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -1,0 +1,15 @@
+customHeaders:
+  - pattern: '**/*'
+    headers:
+      - key: 'Content-Security-Policy'
+        value: "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://www.gstatic.com https://www.google.com https://www.youtube.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net; connect-src 'self' https://*.algolia.net https://*.algolianet.com; frame-src https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com; media-src 'self' https://cpr-documentation-large-files.s3.us-east-2.amazonaws.com; worker-src 'self' blob:; child-src 'self' blob:; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;"
+      - key: 'Strict-Transport-Security'
+        value: 'max-age=63072000; includeSubDomains; preload'
+      - key: 'X-Content-Type-Options'
+        value: 'nosniff'
+      - key: 'X-Frame-Options'
+        value: 'DENY'
+      - key: 'Referrer-Policy'
+        value: 'strict-origin-when-cross-origin'
+      - key: 'Permissions-Policy'
+        value: 'geolocation=(), microphone=(), camera=(), fullscreen=(self)'


### PR DESCRIPTION
Adding a customHTTP.yml file to address Content Security Policy concerns related to the deployed website. The proposed change still allows some external connections so we can still include: embedded Youtube videos, Mermaid diagrams, external fonts, and Algolia DocSearch. AWS Amplify will add these parameters during build.