### PR TITLE
Set proton links to latest released version (1.0.1)

### DIFF
--- a/docs_proton/index.mdx
+++ b/docs_proton/index.mdx
@@ -19,7 +19,7 @@ See the [MCU Protocol](../docs/ros/config/yaml/platform/mcu) section for details
 
 Proton source code is available on GitHub:
 
-- Core libraries: https://github.com/clearpathrobotics/proton
+- Core libraries: https://github.com/clearpathrobotics/proton/tree/1.0.1
 - ROS 2 adapter: https://github.com/clearpathrobotics/proton_ros2
 
 # Key Concepts

--- a/docs_proton/protonc.mdx
+++ b/docs_proton/protonc.mdx
@@ -77,7 +77,7 @@ include(FetchContent)
 FetchContent_Declare(
   proton
   GIT_REPOSITORY https://github.com/clearpathrobotics/proton.git
-  GIT_TAG main
+  GIT_TAG 1.0.1
 )
 
 set(PROTON_BUILD_PROTONCPP OFF)
@@ -1204,7 +1204,7 @@ The Proton node does handle transport timeouts. These should be implemented with
 
 ##### Serial Transport
 
-For serial transport, the `read` and `write` functions must implement Proton's [framing](./index.mdx#serial-transport) to correctly extract the serialized Bundle from the serial stream, and correctly send a Bundle to another peer. The [protoncpp](https://github.com/clearpathrobotics/proton/blob/main/protoncpp/src/transport/serial.cpp) implementation of serial transport can be used as reference.
+For serial transport, the `read` and `write` functions must implement Proton's [framing](./index.mdx#serial-transport) to correctly extract the serialized Bundle from the serial stream, and correctly send a Bundle to another peer. The [protoncpp](https://github.com/clearpathrobotics/proton/blob/1.0.1/protoncpp/src/transport/serial.cpp) implementation of serial transport can be used as reference.
 
 #### Thread Safety
 

--- a/docs_proton/protoncpp.mdx
+++ b/docs_proton/protoncpp.mdx
@@ -66,7 +66,7 @@ include(FetchContent)
 FetchContent_Declare(
   proton
   GIT_REPOSITORY https://github.com/clearpathrobotics/proton.git
-  GIT_TAG main
+  GIT_TAG 1.0.1
 )
 
 set(PROTON_BUILD_PROTONC OFF)


### PR DESCRIPTION
Set proton links to 1.0.1 rather than main, which is not compatible with proton_ros2